### PR TITLE
Feature/allow kcov code exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,6 +913,14 @@ In order to run coverage in a workspace project and package all member coverage 
 cargo make --no-workspace workspace-coverage
 ````
 
+If you are using `kcov`, you may declare the following environmental variables in `Makefile.toml` to specify lines or regions of code to ignore:
+
+```toml
+[env]
+CARGO_MAKE_KCOV_EXCLUDE_LINE = "unreachable,kcov-ignore"             # your choice of pattern(s)
+CARGO_MAKE_KCOV_EXCLUDE_REGION = "kcov-ignore-start:kcov-ignore-end" # your choice of markers
+```
+
 <a name="usage-predefined-flows-cargo"></a>
 #### Cargo Commands and Plugins
 

--- a/examples/kcov.toml
+++ b/examples/kcov.toml
@@ -1,0 +1,8 @@
+
+[env]
+# The following environmental variables are passed to kcov to exclude lines or regions of code
+# during coverage.
+#
+# See examples/workspace3
+CARGO_MAKE_KCOV_EXCLUDE_LINE = "unreachable,kcov-ignore"
+CARGO_MAKE_KCOV_EXCLUDE_REGION = "kcov-ignore-start:kcov-ignore-end"

--- a/examples/workspace3/Cargo.toml
+++ b/examples/workspace3/Cargo.toml
@@ -1,0 +1,3 @@
+
+[workspace]
+members = ["member1", "member2"]

--- a/examples/workspace3/Makefile.toml
+++ b/examples/workspace3/Makefile.toml
@@ -1,0 +1,10 @@
+
+[env]
+# The following environmental variables are passed to kcov to exclude lines or regions of code
+# during coverage.
+CARGO_MAKE_KCOV_EXCLUDE_LINE = "unreachable,kcov-ignore"
+CARGO_MAKE_KCOV_EXCLUDE_REGION = "kcov-ignore-start:kcov-ignore-end"
+
+[tasks.workspace-echo]
+env = { "CARGO_MAKE_MEMBER_TASK" = "echo" }
+run_task = "do-on-members"

--- a/examples/workspace3/member1/Cargo.toml
+++ b/examples/workspace3/member1/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "member1"
+version = "1.0.0"

--- a/examples/workspace3/member1/Makefile.toml
+++ b/examples/workspace3/member1/Makefile.toml
@@ -1,0 +1,3 @@
+
+[tasks.echo]
+script = ["echo hello from member1"]

--- a/examples/workspace3/member1/src/lib.rs
+++ b/examples/workspace3/member1/src/lib.rs
@@ -1,0 +1,30 @@
+pub fn ignore_coverage_1(param: bool) -> Result<(), &'static str> {
+    if param {
+        Ok(())
+    } else {
+        Err("ignore_this") // kcov-ignore
+    }
+}
+
+pub fn ignore_coverage_2(param: bool) -> Result<(), &'static str> {
+    if param || true {
+        Ok(())
+    } else {
+        unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ignore_coverage_1, ignore_coverage_2};
+
+    #[test]
+    fn it_works() {
+        assert_eq!(Ok(()), ignore_coverage_1(true));
+    }
+
+    #[test]
+    fn it_still_works() {
+        assert_eq!(Ok(()), ignore_coverage_2(true));
+    }
+}

--- a/examples/workspace3/member2/Cargo.toml
+++ b/examples/workspace3/member2/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "member2"
+version = "1.0.0"

--- a/examples/workspace3/member2/Makefile.toml
+++ b/examples/workspace3/member2/Makefile.toml
@@ -1,0 +1,3 @@
+
+[tasks.echo]
+script = ["echo hello from member2"]

--- a/examples/workspace3/member2/src/lib.rs
+++ b/examples/workspace3/member2/src/lib.rs
@@ -1,0 +1,20 @@
+pub fn ignore_coverage_region(param: bool) -> Result<(), &'static str> {
+    if param {
+        Ok(())
+    } else {
+        // kcov-ignore-start
+        let _ = 1 + 1;
+        Err("ignore_this")
+        // kcov-ignore-end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ignore_coverage_region;
+
+    #[test]
+    fn it_works() {
+        assert_eq!(Ok(()), ignore_coverage_region(true));
+    }
+}

--- a/src/Makefile.stable.toml
+++ b/src/Makefile.stable.toml
@@ -507,12 +507,22 @@ if [ -n "$CARGO_MAKE_WORKSPACE_TARGET_DIRECTORY" ]; then
     BINARY_DIRECTORY="${CARGO_MAKE_WORKSPACE_TARGET_DIRECTORY}/debug/deps"
 fi
 
+KCOV_EXCLUDE_LINE_ARG=""
+if [ -n "$CARGO_MAKE_KCOV_EXCLUDE_LINE" ]; then
+    KCOV_EXCLUDE_LINE_ARG="--exclude-line=${CARGO_MAKE_KCOV_EXCLUDE_LINE}"
+fi
+
+KCOV_EXCLUDE_REGION_ARG=""
+if [ -n "$CARGO_MAKE_KCOV_EXCLUDE_REGION" ]; then
+    KCOV_EXCLUDE_REGION_ARG="--exclude-region=${CARGO_MAKE_KCOV_EXCLUDE_REGION}"
+fi
+
 echo "Running unit tests from directory: ${BINARY_DIRECTORY}"
 for file in ${BINARY_DIRECTORY}/${CARGO_MAKE_CRATE_FS_NAME}*
 do
     if "$file" ; then
         echo "Running file: $file"
-        kcov --include-pattern=${CARGO_MAKE_WORKING_DIRECTORY}/src/ "$TARGET_DIRECTORY" "$file" || true
+        kcov --include-pattern=${CARGO_MAKE_WORKING_DIRECTORY}/src/ "$KCOV_EXCLUDE_LINE_ARG" "$KCOV_EXCLUDE_REGION_ARG" "$TARGET_DIRECTORY" "$file" || true
     fi
 done
 
@@ -521,7 +531,7 @@ for file in ${BINARY_DIRECTORY}/test_*
 do
     if "$file" ; then
         echo "Running file: $file"
-        kcov --include-pattern=${CARGO_MAKE_WORKING_DIRECTORY}/src/ "$TARGET_DIRECTORY" "$file" || true
+        kcov --include-pattern=${CARGO_MAKE_WORKING_DIRECTORY}/src/ "$KCOV_EXCLUDE_LINE_ARG" "$KCOV_EXCLUDE_REGION_ARG" "$TARGET_DIRECTORY" "$file" || true
     fi
 done
 '''

--- a/src/Makefile.stable.toml
+++ b/src/Makefile.stable.toml
@@ -5,7 +5,7 @@ end_task = "end"
 
 [env]
 RUST_BACKTRACE = "full"
-KCOV_VERSION = "33"
+KCOV_VERSION = "34"
 
 [tasks.default]
 description = "Default task points to the development testing flow"


### PR DESCRIPTION
Hiya, decided to contribute instead of just raise issues :stuck_out_tongue:. This allows users to pass patterns or region markers to kcov for code to ignore during coverage.

They can add the following to their `Makefile.toml`:

```toml
[env]
CARGO_MAKE_KCOV_EXCLUDE_LINE = "unreachable,kcov-ignore"             # your choice of pattern(s)
CARGO_MAKE_KCOV_EXCLUDE_REGION = "kcov-ignore-start:kcov-ignore-end" # your choice of markers
```

The default is empty, so it doesn't affect anyone's existing coverage stats (for better or worse).

I've added `workspace3` in the examples directory which I've tested using `cargo make --no-workspace coverage`.

I'm not sure how the website code is generated, so this branch hasn't updated the `docs` directory.