### PR TITLE
Re-order sed commands for BSD support

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -12,8 +12,8 @@ script = [
 echo "generating readme file"
 rm -f ./README.md
 cat ./docs/_includes/README.md ./docs/_includes/nav.md ./docs/_includes/content.md >> README.md
-sed 's,https://github.com/sagiegurari/cargo-make/blob/master/.github,.github,g' -i ./README.md
-sed "s,{{ site.version }},${CARGO_MAKE_CRATE_VERSION},g" -i ./README.md
+sed -i 's,https://github.com/sagiegurari/cargo-make/blob/master/.github,.github,g' ./README.md
+sed -i "s,{{ site.version }},${CARGO_MAKE_CRATE_VERSION},g" ./README.md
 '''
 ]
 


### PR DESCRIPTION
BSD sed does not support placing flags after positional arguments.