### PR TITLE
Issue 59/update coverage pattern requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,7 +937,7 @@ In order to run coverage in a workspace project and package all member coverage 
 cargo make --no-workspace workspace-coverage
 ````
 
-If you are using **kcov**, you may declare the following environment variables in your Makefile.toml to customize the coverate task:
+If you are using **kcov**, you may declare the following environment variables in your Makefile.toml to customize the coverage task:
 
 Specify lines or regions of code to ignore:
 
@@ -945,6 +945,13 @@ Specify lines or regions of code to ignore:
 [env]
 CARGO_MAKE_KCOV_EXCLUDE_LINE = "unreachable,kcov-ignore"             # your choice of pattern(s)
 CARGO_MAKE_KCOV_EXCLUDE_REGION = "kcov-ignore-start:kcov-ignore-end" # your choice of markers
+````
+
+By default, the binaries executed to collect coverage are filtered by a regular expression. You may override the following in case it does not match the binaries generated on your system:
+
+````toml
+[env]
+CARGO_MAKE_TEST_BINARY_FILTER = "${CARGO_MAKE_CRATE_NAME}-[a-z0-9]*$"
 ````
 
 <a name="usage-predefined-flows-cargo"></a>

--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -879,7 +879,7 @@ In order to run coverage in a workspace project and package all member coverage 
 cargo make --no-workspace workspace-coverage
 ````
 
-If you are using **kcov**, you may declare the following environment variables in your Makefile.toml to customize the coverate task:
+If you are using **kcov**, you may declare the following environment variables in your Makefile.toml to customize the coverage task:
 
 Specify lines or regions of code to ignore:
 
@@ -887,6 +887,13 @@ Specify lines or regions of code to ignore:
 [env]
 CARGO_MAKE_KCOV_EXCLUDE_LINE = "unreachable,kcov-ignore"             # your choice of pattern(s)
 CARGO_MAKE_KCOV_EXCLUDE_REGION = "kcov-ignore-start:kcov-ignore-end" # your choice of markers
+````
+
+By default, the binaries executed to collect coverage are filtered by a regular expression. You may override the following in case it does not match the binaries generated on your system:
+
+````toml
+[env]
+CARGO_MAKE_TEST_BINARY_FILTER = "${CARGO_MAKE_CRATE_NAME}-[a-z0-9]*$"
 ````
 
 <a name="usage-predefined-flows-cargo"></a>

--- a/src/Makefile.stable.toml
+++ b/src/Makefile.stable.toml
@@ -8,6 +8,7 @@ RUST_BACKTRACE = "full"
 KCOV_VERSION = "34"
 CARGO_MAKE_KCOV_EXCLUDE_LINE = "kcov-ignore"
 CARGO_MAKE_KCOV_EXCLUDE_REGION = "kcov-ignore-start:kcov-ignore-end"
+CARGO_MAKE_TEST_BINARY_FILTER = "${CARGO_MAKE_CRATE_NAME}-[a-z0-9]*$"
 
 [tasks.default]
 description = "Default task points to the development testing flow"
@@ -541,12 +542,16 @@ if [ -n "$CARGO_MAKE_KCOV_EXCLUDE_REGION" ]; then
 fi
 
 echo "Running tests from directory: ${BINARY_DIRECTORY}"
-for file in $(find "${BINARY_DIRECTORY}" -maxdepth 1 -type f | grep -v "\.d$\|\.rlib$\|\.so$" | grep -e "-[a-z0-9]*")
+
+# Evaluate variables that may be in the expression
+# This allows us to do double expansion on a non-variable second expansion
+CARGO_MAKE_TEST_BINARY_FILTER_REGEX="$(sh -c "echo \"${CARGO_MAKE_TEST_BINARY_FILTER}\"")"
+echo "Test binary filter regex: ${CARGO_MAKE_TEST_BINARY_FILTER_REGEX}"
+
+for file in $(find "${BINARY_DIRECTORY}" -maxdepth 1 -type f | grep -e "${CARGO_MAKE_TEST_BINARY_FILTER_REGEX}")
 do
-    if "$file" ; then
-        echo "Running file: $file"
-        kcov --include-pattern=${CARGO_MAKE_WORKING_DIRECTORY}/src/ "$KCOV_EXCLUDE_LINE_ARG" "$KCOV_EXCLUDE_REGION_ARG" "$TARGET_DIRECTORY" "$file" || true
-    fi
+    echo "Running file: $file"
+    kcov --include-pattern=${CARGO_MAKE_WORKING_DIRECTORY}/src/ "$KCOV_EXCLUDE_LINE_ARG" "$KCOV_EXCLUDE_REGION_ARG" "$TARGET_DIRECTORY" "$file" || true
 done
 '''
 ]


### PR DESCRIPTION
Addresses issue #59. I've tested this on Ubuntu 17.10 with zsh.

The trickiest part of this was actually getting that double expansion to work; can you check that it works on bash?

I just realized overriding the variable to run my integration test doesn't work for the same reason using `cargo test` didn't work (since `kcov` has to wrap the actual binary call, hah). Anyway the performance improvement is cool :smile: 