### PR TITLE
Makefile.stable/kcov: remove quotes from args

### DIFF
--- a/src/Makefile.stable.toml
+++ b/src/Makefile.stable.toml
@@ -549,7 +549,7 @@ echo "Test binary filter regex: ${CARGO_MAKE_TEST_COVERAGE_BINARY_FILTER_REGEX}"
 for file in $(find "${BINARY_DIRECTORY}" -maxdepth 1 -type f | grep -e "${CARGO_MAKE_TEST_COVERAGE_BINARY_FILTER_REGEX}")
 do
     echo "Running coverage for file: $file"
-    kcov --include-pattern=${CARGO_MAKE_WORKING_DIRECTORY}/src/ "$KCOV_EXCLUDE_LINE_ARG" "$KCOV_EXCLUDE_REGION_ARG" "$TARGET_DIRECTORY" "$file" || true
+    kcov --include-pattern=${CARGO_MAKE_WORKING_DIRECTORY}/src/ ${KCOV_EXCLUDE_LINE_ARG} ${KCOV_EXCLUDE_REGION_ARG} "$TARGET_DIRECTORY" "$file" || true
 done
 '''
 ]


### PR DESCRIPTION
With the quotes, if either of KCOV_EXCLUDE_{LINE,REGION}_ARG is empty it
causes one or two empty strings to be passed as arguments to kcov, which
will lead to an error.