### PR TITLE
WIP: Add support for codecoverage in other CI systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ name = "makers"
 path = "src/makers.rs"
 
 [dependencies]
-ci_info = "^0.2.1"
+ci_info = { git = "https://github.com/sagiegurari/ci_info.git", features = ["serde-1"]}
 clap = "^2.32.0"
 dirs = "^1.0.4"
 fern = "^0.5.7"

--- a/README.md
+++ b/README.md
@@ -915,6 +915,7 @@ In addition to manually setting environment variables, cargo-make will also auto
 * **CARGO_MAKE_CRATE_IS_WORKSPACE** - Holds TRUE/FALSE based if this is a workspace crate or not (defined even if no Cargo.toml is found)
 * **CARGO_MAKE_CRATE_WORKSPACE_MEMBERS** - Holds list of member paths (defined as empty value if no Cargo.toml is found)
 * **CARGO_MAKE_CRATE_LOCK_FILE_EXISTS** - Holds TRUE/FALSE based if a Cargo.lock file exists in current working directory (in workspace projects, each member has a different working directory).
+* **CARGO_MAKE_IS_CI** - Holds TRUE/FALSE based if the task is running in a continuous integration system (such as Travis CI).
 
 The following environment variables will be set by cargo-make if Cargo.toml file exists and the relevant value is defined:
 
@@ -974,7 +975,7 @@ Few examples:
 
 ```toml
 [tasks.test-condition]
-condition = { platforms = ["windows", "linux"], channels = ["beta", "nightly"], env_set = [ "KCOV_VERSION" ], env_not_set = [ "CARGO_MAKE_SKIP_CODECOV" ], env = { "TRAVIS" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" }, rust_version = { min = "1.20.0", max = "1.30.0" } }
+condition = { platforms = ["windows", "linux"], channels = ["beta", "nightly"], env_set = [ "KCOV_VERSION" ], env_not_set = [ "CARGO_MAKE_SKIP_CODECOV" ], env = { "CARGO_MAKE_IS_CI" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" }, rust_version = { min = "1.20.0", max = "1.30.0" } }
 ```
 
 <a name="usage-conditions-script"></a>
@@ -1002,7 +1003,7 @@ For example, if you have a coverage flow that should only be invoked on linux in
 ```toml
 [tasks.ci-coverage-flow]
 description = "Runs the coverage flow and uploads the results to codecov."
-condition = { platforms = ["linux"], env = { "TRAVIS" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" } }
+condition = { platforms = ["linux"], env = { "CARGO_MAKE_IS_CI" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" } }
 run_task = "codecov-flow"
 
 [tasks.codecov-flow]

--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -898,7 +898,7 @@ Few examples:
 
 ```toml
 [tasks.test-condition]
-condition = { platforms = ["windows", "linux"], channels = ["beta", "nightly"], env_set = [ "KCOV_VERSION" ], env_not_set = [ "CARGO_MAKE_SKIP_CODECOV" ], env = { "TRAVIS" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" }, rust_version = { min = "1.20.0", max = "1.30.0" } }
+condition = { platforms = ["windows", "linux"], channels = ["beta", "nightly"], env_set = [ "KCOV_VERSION" ], env_not_set = [ "CARGO_MAKE_SKIP_CODECOV" ], env = { "CARGO_MAKE_IS_CI" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" }, rust_version = { min = "1.20.0", max = "1.30.0" } }
 ```
 
 <a name="usage-conditions-script"></a>
@@ -926,7 +926,7 @@ For example, if you have a coverage flow that should only be invoked on linux in
 ```toml
 [tasks.ci-coverage-flow]
 description = "Runs the coverage flow and uploads the results to codecov."
-condition = { platforms = ["linux"], env = { "TRAVIS" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" } }
+condition = { platforms = ["linux"], env = { "CARGO_MAKE_IS_CI" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" } }
 run_task = "codecov-flow"
 
 [tasks.codecov-flow]

--- a/src/Makefile.stable.toml
+++ b/src/Makefile.stable.toml
@@ -725,7 +725,7 @@ dependencies = [
 [tasks.ci-coverage-flow]
 description = "Runs the coverage flow and uploads the results to codecov."
 category = "CI"
-condition = { platforms = ["linux"], env = { "TRAVIS" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" } }
+condition = { platforms = ["linux"], env = { "CARGO_MAKE_IS_CI" = "true", "CARGO_MAKE_RUN_CODECOV" = "true" } }
 run_task = "codecov-flow"
 
 [tasks.upload-artifacts]

--- a/src/condition_test.rs
+++ b/src/condition_test.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::types::{
-    Config, ConfigSection, CrateInfo, EnvInfo, FlowInfo, GitInfo, RustVersionCondition, Step, Task,
-    TaskCondition,
+    Config, ConfigSection, EnvInfo, FlowInfo, RustVersionCondition, Step, Task, TaskCondition,
 };
 use indexmap::IndexMap;
 use rust_info::types::{RustChannel, RustInfo};
@@ -344,11 +343,7 @@ fn validate_channel_valid() {
     let mut flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -415,11 +410,7 @@ fn validate_channel_invalid() {
     let mut flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -454,11 +445,7 @@ fn validate_criteria_empty() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -493,11 +480,7 @@ fn validate_criteria_valid_platform() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -536,11 +519,7 @@ fn validate_criteria_invalid_platform() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -575,11 +554,7 @@ fn validate_criteria_valid_channel() {
     let mut flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -652,11 +627,7 @@ fn validate_criteria_invalid_channel() {
     let mut flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -691,11 +662,7 @@ fn validate_condition_both_valid() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -735,11 +702,7 @@ fn validate_criteria_valid_script_invalid() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -779,11 +742,7 @@ fn validate_criteria_invalid_script_valid() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -819,11 +778,7 @@ fn validate_criteria_invalid_env_set() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -859,11 +814,7 @@ fn validate_criteria_invalid_env_not_set() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -901,11 +852,7 @@ fn validate_criteria_valid_env() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -948,11 +895,7 @@ fn validate_criteria_invalid_env_not_found() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -992,11 +935,7 @@ fn validate_criteria_invalid_env_not_equal() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -1039,11 +978,7 @@ fn validate_criteria_valid_rust_version() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -1085,11 +1020,7 @@ fn validate_criteria_invalid_rust_version() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,

--- a/src/environment/executioninfo.rs
+++ b/src/environment/executioninfo.rs
@@ -1,0 +1,16 @@
+//! # executioninfo
+//!
+//! Gets information about the execution environment.
+//!
+
+use ci_info;
+use ci_info::types::Vendor;
+
+pub(crate) fn current_ci_vendor() -> Option<Vendor> {
+    let info = ci_info::get();
+    info.vendor
+}
+
+pub(crate) fn is_ci() -> bool {
+    ci_info::is_ci()
+}

--- a/src/environment/mod_test.rs
+++ b/src/environment/mod_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use ci_info::types::Vendor;
 use crate::types::{ConfigSection, Task};
 use indexmap::IndexMap;
 use std::env;
@@ -475,6 +476,27 @@ fn setup_env_for_git_repo_with_values() {
             git_info.user_email.unwrap()
         );
     }
+}
+
+#[test]
+fn setup_env_for_execution_ci_check() {
+    env::remove_var("CARGO_MAKE_IS_CI");
+    env::remove_var("TRAVIS");
+
+    let execution_info = setup_env_for_execution();
+    assert_ne!(execution_info.ci_vendor, Some(Vendor::TRAVIS));
+    assert_eq!(
+        env::var_os("CARGO_MAKE_IS_CI").unwrap(),
+        if ci_info::is_ci() { "TRUE" } else { "FALSE" }
+    );
+
+    env::remove_var("CARGO_MAKE_IS_CI");
+    env::set_var("TRAVIS", "true");
+    let execution_info = setup_env_for_execution();
+    // This check is brittle in CI and depends on travis taking precedence
+    // if run elsewhere.
+    assert_eq!(execution_info.ci_vendor, Some(Vendor::TRAVIS));
+    assert_eq!(env::var_os("CARGO_MAKE_IS_CI").unwrap(), "TRUE");
 }
 
 #[test]

--- a/src/runner_test.rs
+++ b/src/runner_test.rs
@@ -1,10 +1,9 @@
 use super::*;
 use crate::types::{
-    ConfigSection, CrateInfo, EnvInfo, EnvValue, FlowInfo, GitInfo, PlatformOverrideTask, Step,
-    Task, Workspace,
+    ConfigSection, CrateInfo, EnvInfo, EnvValue, FlowInfo, PlatformOverrideTask, Step, Task,
+    Workspace,
 };
 use indexmap::IndexMap;
-use rust_info::types::RustInfo;
 use std::env;
 
 #[test]
@@ -548,11 +547,7 @@ fn run_task_bad_script() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -580,11 +575,7 @@ fn run_task_script_with_args_error() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: Some(vec!["1".to_string()]),
@@ -611,11 +602,7 @@ fn run_task_script_with_args_valid() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: Some(vec!["0".to_string()]),
@@ -641,11 +628,7 @@ fn run_task_command() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -673,11 +656,7 @@ fn run_task_bad_command_valid_script() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -704,11 +683,7 @@ fn run_task_no_command_valid_script() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -741,11 +716,7 @@ fn run_task_bad_run_task_valid_command() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -779,11 +750,7 @@ fn run_task_valid_run_task() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -810,11 +777,7 @@ fn run_task_invalid_task() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -841,11 +804,7 @@ fn run_task_set_env() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -884,11 +843,7 @@ fn run_task_cwd_no_such_dir() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,
@@ -915,11 +870,7 @@ fn run_task_cwd_dir_exists() {
     let flow_info = FlowInfo {
         config,
         task: "test".to_string(),
-        env_info: EnvInfo {
-            rust_info: RustInfo::new(),
-            crate_info: CrateInfo::new(),
-            git_info: GitInfo::new(),
-        },
+        env_info: EnvInfo::default(),
         disable_workspace: false,
         disable_on_error: false,
         cli_arguments: None,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,5 @@
 use ci_info;
+use ci_info::types::Vendor;
 use rust_info;
 use rust_info::types::RustChannel;
 use std::env;
@@ -6,10 +7,12 @@ use std::fs::{create_dir_all, remove_dir_all};
 use std::path::PathBuf;
 
 fn is_travis_ci() -> bool {
-    match env::var("TRAVIS") {
-        Ok(value) => value == "true",
-        _ => false,
-    }
+    let info = ci_info::get();
+    return if let Some(vendor) = info.vendor {
+        vendor == Vendor::TRAVIS
+    } else {
+        false
+    };
 }
 
 pub(crate) fn should_test(panic_if_false: bool) -> bool {

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,7 @@
 #[path = "./types_test.rs"]
 mod types_test;
 
+use ci_info::types::Vendor;
 use indexmap::IndexMap;
 use rust_info::types::RustInfo;
 
@@ -239,6 +240,20 @@ impl CrateInfo {
     }
 }
 
+#[derive(Deserialize, Debug, Clone, Copy)]
+/// Holds information about the execution environment.
+pub struct ExecutionInfo {
+    /// the continuous integration vendor.
+    pub ci_vendor: Option<Vendor>,
+}
+
+impl ExecutionInfo {
+    /// Creates and returns a new instance.
+    pub fn new() -> ExecutionInfo {
+        ExecutionInfo { ci_vendor: None }
+    }
+}
+
 #[derive(Debug, Clone)]
 /// Holds env information
 pub struct EnvInfo {
@@ -248,6 +263,19 @@ pub struct EnvInfo {
     pub crate_info: CrateInfo,
     /// Git info
     pub git_info: GitInfo,
+    /// Execution info
+    pub execution_info: ExecutionInfo,
+}
+
+impl Default for EnvInfo {
+    fn default() -> EnvInfo {
+        EnvInfo {
+            rust_info: RustInfo::new(),
+            crate_info: CrateInfo::new(),
+            git_info: GitInfo::new(),
+            execution_info: ExecutionInfo::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Partial step towards https://github.com/sagiegurari/cargo-make/issues/116.

This is WIP until a new release of `ci_info` is pushed to crates.io and I figure out the token stuff.

