### PR TITLE
Changed default version of cargo-watch to a working one

### DIFF
--- a/src/lib/runner.rs
+++ b/src/lib/runner.rs
@@ -256,7 +256,7 @@ fn create_watch_task(task: &str, options: Option<TaskWatchOptions>) -> Task {
             TaskWatchOptions::Options(watch_options) => {
                 let watch_version = match watch_options.version {
                     Some(value) => value.to_string(),
-                    _ => "7.0.8".to_string(), // currently certified version
+                    _ => "7.2.1".to_string(), // current version
                 };
                 task_config.install_crate_args = Some(vec!["--version".to_string(), watch_version]);
 


### PR DESCRIPTION
Using a default watch version of `7.08` may result in errors if `watch` is used in makefiles without `cargo-watch` being currently installed, as shown in the issue linked below. Version `7.2.1` fixes this.

https://github.com/David-OConnor/seed-quickstart/issues/7