### PR TITLE
Allow passing an array of argument to test_arg

### DIFF
--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -1236,6 +1236,18 @@ command = "rustfmt"
 In this example, cargo will first test that the command ```rustfmt --help``` works well and only if fails, it will first attempt
 to install via rustup the component **rustfmt-preview** and if failed, it will try to run cargo install for the crate name **rustfmt-nightly**.
 
+If passing multiple arguments is necessary, `test_arg` may contain an array of arguments. For example:
+
+```toml
+[tasks.doc-upload]
+install_crate = { crate_name = "cargo-travis", binary = "cargo", test_arg = ["doc-upload", "--help"] }
+command = "cargo"
+args = ["doc-upload"]
+```
+
+In this example, cargo-make will test the presence of cargo-travis by running the command `cargo doc-upload --help`, and
+install the crate only if this command fails.
+
 <a name="usage-installing-rustup-components"></a>
 #### Rustup Components
 

--- a/src/lib/installer/crate_installer.rs
+++ b/src/lib/installer/crate_installer.rs
@@ -18,7 +18,8 @@ fn invoke_rustup_install(toolchain: &Option<String>, info: &InstallCrateInfo) ->
             let rustup_component_info = InstallRustupComponentInfo {
                 rustup_component_name: component.to_string(),
                 binary: Some(info.binary.clone()),
-                test_arg: Some(info.test_arg.clone()),
+                // InstallRustupComponentInfo only supports one argument right now.
+                test_arg: info.test_arg.get(0).cloned(),
             };
             rustup_component_installer::invoke_rustup_install(&toolchain, &rustup_component_info)
         }

--- a/src/lib/installer/crate_installer.rs
+++ b/src/lib/installer/crate_installer.rs
@@ -18,8 +18,7 @@ fn invoke_rustup_install(toolchain: &Option<String>, info: &InstallCrateInfo) ->
             let rustup_component_info = InstallRustupComponentInfo {
                 rustup_component_name: component.to_string(),
                 binary: Some(info.binary.clone()),
-                // InstallRustupComponentInfo only supports one argument right now.
-                test_arg: info.test_arg.get(0).cloned(),
+                test_arg: Some(info.test_arg.clone()),
             };
             rustup_component_installer::invoke_rustup_install(&toolchain, &rustup_component_info)
         }

--- a/src/lib/installer/crate_installer_test.rs
+++ b/src/lib/installer/crate_installer_test.rs
@@ -1,12 +1,13 @@
 use super::*;
 use crate::test;
+use crate::types::TestArg;
 
 #[test]
 fn invoke_rustup_install_none() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
 
@@ -19,7 +20,7 @@ fn invoke_rustup_install_fail() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -34,7 +35,7 @@ fn invoke_rustup_install_with_toolchain_none() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
 
@@ -49,7 +50,7 @@ fn invoke_rustup_install_with_toolchain_fail() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -62,7 +63,7 @@ fn invoke_cargo_install_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -76,7 +77,7 @@ fn invoke_cargo_install_with_toolchain_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -88,7 +89,7 @@ fn install_test_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -102,7 +103,7 @@ fn install_test_with_toolchain_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 

--- a/src/lib/installer/crate_installer_test.rs
+++ b/src/lib/installer/crate_installer_test.rs
@@ -6,7 +6,7 @@ fn invoke_rustup_install_none() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
 
@@ -19,7 +19,7 @@ fn invoke_rustup_install_fail() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -34,7 +34,7 @@ fn invoke_rustup_install_with_toolchain_none() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
 
@@ -49,7 +49,7 @@ fn invoke_rustup_install_with_toolchain_fail() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -62,7 +62,7 @@ fn invoke_cargo_install_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -76,7 +76,7 @@ fn invoke_cargo_install_with_toolchain_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -88,7 +88,7 @@ fn install_test_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -102,7 +102,7 @@ fn install_test_with_toolchain_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 

--- a/src/lib/installer/crate_installer_test.rs
+++ b/src/lib/installer/crate_installer_test.rs
@@ -7,7 +7,9 @@ fn invoke_rustup_install_none() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
 
@@ -20,7 +22,9 @@ fn invoke_rustup_install_fail() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -35,7 +39,9 @@ fn invoke_rustup_install_with_toolchain_none() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
 
@@ -50,7 +56,9 @@ fn invoke_rustup_install_with_toolchain_fail() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "test".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -63,7 +71,9 @@ fn invoke_cargo_install_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -77,7 +87,9 @@ fn invoke_cargo_install_with_toolchain_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -89,7 +101,9 @@ fn install_test_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 
@@ -103,7 +117,9 @@ fn install_test_with_toolchain_test() {
     let info = InstallCrateInfo {
         crate_name: "bad_crate_name".to_string(),
         binary: "cargo_bad".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("unknown_rustup_component_test".to_string()),
     };
 

--- a/src/lib/installer/mod_test.rs
+++ b/src/lib/installer/mod_test.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::types::{InstallCrateInfo, InstallRustupComponentInfo};
+use crate::types::{InstallCrateInfo, InstallRustupComponentInfo, TestArg};
 
 #[test]
 fn install_empty() {
@@ -52,7 +52,7 @@ fn install_rustup_via_crate_info() {
     let info = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "cargo".to_string(),
-        test_arg: vec!["--version".to_string()],
+        test_arg: TestArg { inner: vec!["--version".to_string()] },
         rustup_component_name: None,
     };
 
@@ -68,7 +68,7 @@ fn install_rustup_via_rustup_info() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "test".to_string(),
         binary: Some("cargo".to_string()),
-        test_arg: Some("--version".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--version".to_string()] }),
     };
 
     let mut task = Task::new();

--- a/src/lib/installer/mod_test.rs
+++ b/src/lib/installer/mod_test.rs
@@ -52,7 +52,7 @@ fn install_rustup_via_crate_info() {
     let info = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "cargo".to_string(),
-        test_arg: "--version".to_string(),
+        test_arg: vec!["--version".to_string()],
         rustup_component_name: None,
     };
 

--- a/src/lib/installer/mod_test.rs
+++ b/src/lib/installer/mod_test.rs
@@ -52,7 +52,9 @@ fn install_rustup_via_crate_info() {
     let info = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "cargo".to_string(),
-        test_arg: TestArg { inner: vec!["--version".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--version".to_string()],
+        },
         rustup_component_name: None,
     };
 
@@ -68,7 +70,9 @@ fn install_rustup_via_rustup_info() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "test".to_string(),
         binary: Some("cargo".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--version".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--version".to_string()],
+        }),
     };
 
     let mut task = Task::new();

--- a/src/lib/installer/rustup_component_installer.rs
+++ b/src/lib/installer/rustup_component_installer.rs
@@ -12,7 +12,7 @@ use crate::toolchain::wrap_command;
 use crate::types::InstallRustupComponentInfo;
 use std::process::Command;
 
-pub(crate) fn is_installed(toolchain: &Option<String>, binary: &str, test_arg: &str) -> bool {
+pub(crate) fn is_installed(toolchain: &Option<String>, binary: &str, test_args: &[String]) -> bool {
     let mut command_struct = match toolchain {
         Some(ref toolchain_string) => {
             let command_spec = wrap_command(toolchain_string, binary, &None);
@@ -28,7 +28,7 @@ pub(crate) fn is_installed(toolchain: &Option<String>, binary: &str, test_arg: &
         None => Command::new(binary),
     };
 
-    let result = command_struct.arg(test_arg).output();
+    let result = command_struct.args(test_args).output();
 
     match result {
         Ok(output) => {
@@ -105,7 +105,7 @@ pub(crate) fn install(
 ) -> bool {
     let mut installed = match info.binary {
         Some(ref binary) => match info.test_arg {
-            Some(ref test_arg) => is_installed(&toolchain, binary, test_arg),
+            Some(ref test_arg) => is_installed(&toolchain, binary, std::slice::from_ref(test_arg)),
             None => false,
         },
         None => false,

--- a/src/lib/installer/rustup_component_installer.rs
+++ b/src/lib/installer/rustup_component_installer.rs
@@ -105,7 +105,7 @@ pub(crate) fn install(
 ) -> bool {
     let mut installed = match info.binary {
         Some(ref binary) => match info.test_arg {
-            Some(ref test_arg) => is_installed(&toolchain, binary, std::slice::from_ref(test_arg)),
+            Some(ref test_arg) => is_installed(&toolchain, binary, test_arg),
             None => false,
         },
         None => false,

--- a/src/lib/installer/rustup_component_installer_test.rs
+++ b/src/lib/installer/rustup_component_installer_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::test;
+use crate::types::TestArg;
 
 #[test]
 fn is_installed_true() {
@@ -52,7 +53,7 @@ fn invoke_rustup_install_fail() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "unknown_rustup_component_test".to_string(),
         binary: Some("cargo_bad".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     let output = invoke_rustup_install(&None, &info);
@@ -66,7 +67,7 @@ fn invoke_rustup_install_with_toolchain_fail() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "unknown_rustup_component_test".to_string(),
         binary: Some("cargo_bad".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     let output = invoke_rustup_install(&Some(toolchain), &info);
@@ -78,7 +79,7 @@ fn install_test() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "unknown_rustup_component_test".to_string(),
         binary: Some("cargo_bad".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     let output = install(&None, &info, false);
@@ -92,7 +93,7 @@ fn install_with_toolchain_test() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "unknown_rustup_component_test".to_string(),
         binary: Some("cargo_bad".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     let output = install(&Some(toolchain), &info, false);

--- a/src/lib/installer/rustup_component_installer_test.rs
+++ b/src/lib/installer/rustup_component_installer_test.rs
@@ -3,19 +3,19 @@ use crate::test;
 
 #[test]
 fn is_installed_true() {
-    let output = is_installed(&None, "cargo", "--version");
+    let output = is_installed(&None, "cargo", &["--version".to_string()]);
     assert!(output);
 }
 
 #[test]
 fn is_installed_false() {
-    let output = is_installed(&None, "cargo_bad", "--version");
+    let output = is_installed(&None, "cargo_bad", &["--version".to_string()]);
     assert!(!output);
 }
 
 #[test]
 fn is_installed_non_zero() {
-    let output = is_installed(&None, "exit", "1");
+    let output = is_installed(&None, "exit", &["1".to_string()]);
     assert!(!output);
 }
 
@@ -24,7 +24,7 @@ fn is_installed_with_toolchain_true() {
     if test::is_not_rust_stable() {
         let toolchain = test::get_toolchain();
 
-        let output = is_installed(&Some(toolchain), "cargo", "--version");
+        let output = is_installed(&Some(toolchain), "cargo", &["--version".to_string()]);
         assert!(output);
     }
 }
@@ -34,7 +34,7 @@ fn is_installed_with_toolchain_false() {
     if test::is_not_rust_stable() {
         let toolchain = test::get_toolchain();
 
-        let output = is_installed(&Some(toolchain), "cargo_bad", "--version");
+        let output = is_installed(&Some(toolchain), "cargo_bad", &["--version".to_string()]);
         assert!(!output);
     }
 }
@@ -43,7 +43,7 @@ fn is_installed_with_toolchain_false() {
 fn is_installed_with_toolchain_non_zero() {
     let toolchain = test::get_toolchain();
 
-    let output = is_installed(&Some(toolchain), "exit", "1");
+    let output = is_installed(&Some(toolchain), "exit", &["1".to_string()]);
     assert!(!output);
 }
 

--- a/src/lib/installer/rustup_component_installer_test.rs
+++ b/src/lib/installer/rustup_component_installer_test.rs
@@ -53,7 +53,9 @@ fn invoke_rustup_install_fail() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "unknown_rustup_component_test".to_string(),
         binary: Some("cargo_bad".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     let output = invoke_rustup_install(&None, &info);
@@ -67,7 +69,9 @@ fn invoke_rustup_install_with_toolchain_fail() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "unknown_rustup_component_test".to_string(),
         binary: Some("cargo_bad".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     let output = invoke_rustup_install(&Some(toolchain), &info);
@@ -79,7 +83,9 @@ fn install_test() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "unknown_rustup_component_test".to_string(),
         binary: Some("cargo_bad".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     let output = install(&None, &info, false);
@@ -93,7 +99,9 @@ fn install_with_toolchain_test() {
     let info = InstallRustupComponentInfo {
         rustup_component_name: "unknown_rustup_component_test".to_string(),
         binary: Some("cargo_bad".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     let output = install(&Some(toolchain), &info, false);

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -370,7 +370,7 @@ pub enum EnvValue {
 #[serde(transparent)]
 pub struct TestArg {
     /// Content of the arguments
-    pub inner: Vec<String>
+    pub inner: Vec<String>,
 }
 
 impl std::ops::Deref for TestArg {
@@ -386,8 +386,7 @@ impl std::ops::DerefMut for TestArg {
     }
 }
 
-impl<'de> serde::de::Deserialize<'de> for TestArg
-{
+impl<'de> serde::de::Deserialize<'de> for TestArg {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::de::Deserializer<'de>,
@@ -404,12 +403,14 @@ impl<'de> serde::de::Deserialize<'de> for TestArg
             where
                 E: serde::de::Error,
             {
-                Ok(TestArg { inner: vec![s.to_string()] })
+                Ok(TestArg {
+                    inner: vec![s.to_string()],
+                })
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
             where
-                A: serde::de::SeqAccess<'de>
+                A: serde::de::SeqAccess<'de>,
             {
                 let mut v = Vec::with_capacity(seq.size_hint().unwrap_or(0));
                 while let Some(s) = seq.next_element()? {

--- a/src/lib/types_test.rs
+++ b/src/lib/types_test.rs
@@ -50,13 +50,17 @@ fn install_crate_info_eq_same_all() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("component".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("component".to_string()),
     };
 
@@ -68,13 +72,17 @@ fn install_crate_info_eq_same_no_component() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
 
@@ -86,13 +94,17 @@ fn install_crate_info_eq_different_crate_name() {
     let first = InstallCrateInfo {
         crate_name: "test1".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test2".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
 
@@ -104,13 +116,17 @@ fn install_crate_info_eq_different_binary() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin1".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin2".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
 
@@ -122,13 +138,17 @@ fn install_crate_info_eq_different_test_arg() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help1".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help1".to_string()],
+        },
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help2".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help2".to_string()],
+        },
         rustup_component_name: None,
     };
 
@@ -140,13 +160,17 @@ fn install_crate_info_eq_different_component_type() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("value".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: None,
     };
 
@@ -158,13 +182,17 @@ fn install_crate_info_eq_different_component_value() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("value1".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("value2".to_string()),
     };
 
@@ -176,12 +204,16 @@ fn install_rustup_component_info_eq_same_all() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     assert_eq!(first, second);
@@ -192,12 +224,16 @@ fn install_rustup_component_info_eq_same_no_binary() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: None,
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: None,
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     assert_eq!(first, second);
@@ -224,12 +260,16 @@ fn install_rustup_component_info_eq_different_component() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component1".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component2".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     assert!(first != second);
@@ -240,12 +280,16 @@ fn install_rustup_component_info_eq_different_binary() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin1".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin2".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     assert!(first != second);
@@ -256,12 +300,16 @@ fn install_rustup_component_info_eq_different_binary_type() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: None,
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     assert!(first != second);
@@ -272,12 +320,16 @@ fn install_rustup_component_info_eq_different_test_arg() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--hel1p".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--hel1p".to_string()],
+        }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help2".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help2".to_string()],
+        }),
     };
 
     assert!(first != second);
@@ -293,7 +345,9 @@ fn install_rustup_component_info_eq_different_test_arg_type() {
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: None,
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     };
 
     assert!(first != second);
@@ -312,7 +366,9 @@ fn install_crate_eq_same_info() {
     let info = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("value".to_string()),
     };
     let first = InstallCrate::CrateInfo(info.clone());
@@ -334,13 +390,17 @@ fn install_crate_eq_different_crate_info() {
     let first = InstallCrate::CrateInfo(InstallCrateInfo {
         crate_name: "test1".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("value".to_string()),
     });
     let second = InstallCrate::CrateInfo(InstallCrateInfo {
         crate_name: "test2".to_string(),
         binary: "bin".to_string(),
-        test_arg: TestArg { inner: vec!["--help".to_string()] },
+        test_arg: TestArg {
+            inner: vec!["--help".to_string()],
+        },
         rustup_component_name: Some("value".to_string()),
     });
 
@@ -349,47 +409,65 @@ fn install_crate_eq_different_crate_info() {
 
 #[test]
 fn install_crate_info_deserialize_string_test_arg() {
-    let info: InstallCrateInfo = toml::from_str(r#"crate_name = "mkisofs-rs"
+    let info: InstallCrateInfo = toml::from_str(
+        r#"crate_name = "mkisofs-rs"
                                                    binary = "mkisofs-rs"
-                                                   test_arg = "--help""#).unwrap();
+                                                   test_arg = "--help""#,
+    )
+    .unwrap();
     assert_eq!(*info.test_arg, &["--help"]);
 }
 
 #[test]
 fn install_crate_info_deserialize_array_test_arg() {
-    let info: InstallCrateInfo = toml::from_str(r#"crate_name = "mkisofs-rs"
+    let info: InstallCrateInfo = toml::from_str(
+        r#"crate_name = "mkisofs-rs"
                                                    binary = "mkisofs-rs"
-                                                   test_arg = ["--help", "--test"]"#).unwrap();
+                                                   test_arg = ["--help", "--test"]"#,
+    )
+    .unwrap();
     assert_eq!(*info.test_arg, &["--help", "--test"]);
 }
 
 #[test]
 #[should_panic]
 fn install_crate_info_deserialize_missing_test_arg() {
-    let _info: InstallCrateInfo = toml::from_str(r#"crate_name = "mkisofs-rs"
-                                                   binary = "mkisofs-rs"#).unwrap();
+    let _info: InstallCrateInfo = toml::from_str(
+        r#"crate_name = "mkisofs-rs"
+                                                   binary = "mkisofs-rs"#,
+    )
+    .unwrap();
 }
 
 #[test]
 fn install_rustup_component_info_deserialize_string_test_arg() {
-    let info: InstallRustupComponentInfo = toml::from_str(r#"rustup_component_name = "clippy-preview"
+    let info: InstallRustupComponentInfo = toml::from_str(
+        r#"rustup_component_name = "clippy-preview"
                                                              binary = "cargo-clippy"
-                                                             test_arg = "--help""#).unwrap();
+                                                             test_arg = "--help""#,
+    )
+    .unwrap();
     assert_eq!(*info.test_arg.unwrap(), &["--help"]);
 }
 
 #[test]
 fn install_rustup_component_info_deserialize_array_test_arg() {
-    let info: InstallRustupComponentInfo = toml::from_str(r#"rustup_component_name = "clippy-preview"
+    let info: InstallRustupComponentInfo = toml::from_str(
+        r#"rustup_component_name = "clippy-preview"
                                                              binary = "cargo"
-                                                             test_arg = ["clippy", "--help"]"#).unwrap();
+                                                             test_arg = ["clippy", "--help"]"#,
+    )
+    .unwrap();
     assert_eq!(*info.test_arg.unwrap(), &["clippy", "--help"]);
 }
 
 #[test]
 fn install_rustup_component_info_deserialize_missing_test_arg() {
-    let info: InstallRustupComponentInfo = toml::from_str(r#"rustup_component_name = "clippy-preview"
-                                                             binary = "cargo""#).unwrap();
+    let info: InstallRustupComponentInfo = toml::from_str(
+        r#"rustup_component_name = "clippy-preview"
+                                                             binary = "cargo""#,
+    )
+    .unwrap();
 
     assert_eq!(info.test_arg, None);
 }
@@ -399,12 +477,16 @@ fn install_crate_eq_different_rustup_component_info() {
     let first = InstallCrate::RustupComponentInfo(InstallRustupComponentInfo {
         rustup_component_name: "component1".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     });
     let second = InstallCrate::RustupComponentInfo(InstallRustupComponentInfo {
         rustup_component_name: "component2".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
+        test_arg: Some(TestArg {
+            inner: vec!["--help".to_string()],
+        }),
     });
 
     assert!(first != second);

--- a/src/lib/types_test.rs
+++ b/src/lib/types_test.rs
@@ -50,13 +50,13 @@ fn install_crate_info_eq_same_all() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("component".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("component".to_string()),
     };
 
@@ -68,13 +68,13 @@ fn install_crate_info_eq_same_no_component() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
 
@@ -86,13 +86,13 @@ fn install_crate_info_eq_different_crate_name() {
     let first = InstallCrateInfo {
         crate_name: "test1".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test2".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
 
@@ -104,13 +104,13 @@ fn install_crate_info_eq_different_binary() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin1".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin2".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
 
@@ -122,13 +122,13 @@ fn install_crate_info_eq_different_test_arg() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help1".to_string(),
+        test_arg: vec!["--help1".to_string()],
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help2".to_string(),
+        test_arg: vec!["--help2".to_string()],
         rustup_component_name: None,
     };
 
@@ -140,13 +140,13 @@ fn install_crate_info_eq_different_component_type() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("value".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: None,
     };
 
@@ -158,13 +158,13 @@ fn install_crate_info_eq_different_component_value() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("value1".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("value2".to_string()),
     };
 
@@ -312,7 +312,7 @@ fn install_crate_eq_same_info() {
     let info = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("value".to_string()),
     };
     let first = InstallCrate::CrateInfo(info.clone());
@@ -334,13 +334,13 @@ fn install_crate_eq_different_crate_info() {
     let first = InstallCrate::CrateInfo(InstallCrateInfo {
         crate_name: "test1".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("value".to_string()),
     });
     let second = InstallCrate::CrateInfo(InstallCrateInfo {
         crate_name: "test2".to_string(),
         binary: "bin".to_string(),
-        test_arg: "--help".to_string(),
+        test_arg: vec!["--help".to_string()],
         rustup_component_name: Some("value".to_string()),
     });
 

--- a/src/lib/types_test.rs
+++ b/src/lib/types_test.rs
@@ -348,6 +348,22 @@ fn install_crate_eq_different_crate_info() {
 }
 
 #[test]
+fn install_crate_info_deserialize_string_test_arg() {
+    let info: InstallCrateInfo = toml::from_str(r#"crate_name = "mkisofs-rs"
+                                                   binary = "mkisofs-rs"
+                                                   test_arg = "--help""#).unwrap();
+    assert_eq!(info.test_arg, &["--help"]);
+}
+
+#[test]
+fn install_crate_info_deserialize_array_test_arg() {
+    let info: InstallCrateInfo = toml::from_str(r#"crate_name = "mkisofs-rs"
+                                                   binary = "mkisofs-rs"
+                                                   test_arg = ["--help", "--test"]"#).unwrap();
+    assert_eq!(info.test_arg, &["--help", "--test"]);
+}
+
+#[test]
 fn install_crate_eq_different_rustup_component_info() {
     let first = InstallCrate::RustupComponentInfo(InstallRustupComponentInfo {
         rustup_component_name: "component1".to_string(),

--- a/src/lib/types_test.rs
+++ b/src/lib/types_test.rs
@@ -50,13 +50,13 @@ fn install_crate_info_eq_same_all() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("component".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("component".to_string()),
     };
 
@@ -68,13 +68,13 @@ fn install_crate_info_eq_same_no_component() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
 
@@ -86,13 +86,13 @@ fn install_crate_info_eq_different_crate_name() {
     let first = InstallCrateInfo {
         crate_name: "test1".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test2".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
 
@@ -104,13 +104,13 @@ fn install_crate_info_eq_different_binary() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin1".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin2".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
 
@@ -122,13 +122,13 @@ fn install_crate_info_eq_different_test_arg() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help1".to_string()],
+        test_arg: TestArg { inner: vec!["--help1".to_string()] },
         rustup_component_name: None,
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help2".to_string()],
+        test_arg: TestArg { inner: vec!["--help2".to_string()] },
         rustup_component_name: None,
     };
 
@@ -140,13 +140,13 @@ fn install_crate_info_eq_different_component_type() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("value".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: None,
     };
 
@@ -158,13 +158,13 @@ fn install_crate_info_eq_different_component_value() {
     let first = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("value1".to_string()),
     };
     let second = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("value2".to_string()),
     };
 
@@ -176,12 +176,12 @@ fn install_rustup_component_info_eq_same_all() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     assert_eq!(first, second);
@@ -192,12 +192,12 @@ fn install_rustup_component_info_eq_same_no_binary() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: None,
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: None,
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     assert_eq!(first, second);
@@ -224,12 +224,12 @@ fn install_rustup_component_info_eq_different_component() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component1".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component2".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     assert!(first != second);
@@ -240,12 +240,12 @@ fn install_rustup_component_info_eq_different_binary() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin1".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin2".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     assert!(first != second);
@@ -256,12 +256,12 @@ fn install_rustup_component_info_eq_different_binary_type() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: None,
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     assert!(first != second);
@@ -272,12 +272,12 @@ fn install_rustup_component_info_eq_different_test_arg() {
     let first = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--hel1p".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--hel1p".to_string()] }),
     };
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--help2".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help2".to_string()] }),
     };
 
     assert!(first != second);
@@ -293,7 +293,7 @@ fn install_rustup_component_info_eq_different_test_arg_type() {
     let second = InstallRustupComponentInfo {
         rustup_component_name: "component".to_string(),
         binary: None,
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     };
 
     assert!(first != second);
@@ -312,7 +312,7 @@ fn install_crate_eq_same_info() {
     let info = InstallCrateInfo {
         crate_name: "test".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("value".to_string()),
     };
     let first = InstallCrate::CrateInfo(info.clone());
@@ -334,13 +334,13 @@ fn install_crate_eq_different_crate_info() {
     let first = InstallCrate::CrateInfo(InstallCrateInfo {
         crate_name: "test1".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("value".to_string()),
     });
     let second = InstallCrate::CrateInfo(InstallCrateInfo {
         crate_name: "test2".to_string(),
         binary: "bin".to_string(),
-        test_arg: vec!["--help".to_string()],
+        test_arg: TestArg { inner: vec!["--help".to_string()] },
         rustup_component_name: Some("value".to_string()),
     });
 
@@ -352,7 +352,7 @@ fn install_crate_info_deserialize_string_test_arg() {
     let info: InstallCrateInfo = toml::from_str(r#"crate_name = "mkisofs-rs"
                                                    binary = "mkisofs-rs"
                                                    test_arg = "--help""#).unwrap();
-    assert_eq!(info.test_arg, &["--help"]);
+    assert_eq!(*info.test_arg, &["--help"]);
 }
 
 #[test]
@@ -360,7 +360,38 @@ fn install_crate_info_deserialize_array_test_arg() {
     let info: InstallCrateInfo = toml::from_str(r#"crate_name = "mkisofs-rs"
                                                    binary = "mkisofs-rs"
                                                    test_arg = ["--help", "--test"]"#).unwrap();
-    assert_eq!(info.test_arg, &["--help", "--test"]);
+    assert_eq!(*info.test_arg, &["--help", "--test"]);
+}
+
+#[test]
+#[should_panic]
+fn install_crate_info_deserialize_missing_test_arg() {
+    let _info: InstallCrateInfo = toml::from_str(r#"crate_name = "mkisofs-rs"
+                                                   binary = "mkisofs-rs"#).unwrap();
+}
+
+#[test]
+fn install_rustup_component_info_deserialize_string_test_arg() {
+    let info: InstallRustupComponentInfo = toml::from_str(r#"rustup_component_name = "clippy-preview"
+                                                             binary = "cargo-clippy"
+                                                             test_arg = "--help""#).unwrap();
+    assert_eq!(*info.test_arg.unwrap(), &["--help"]);
+}
+
+#[test]
+fn install_rustup_component_info_deserialize_array_test_arg() {
+    let info: InstallRustupComponentInfo = toml::from_str(r#"rustup_component_name = "clippy-preview"
+                                                             binary = "cargo"
+                                                             test_arg = ["clippy", "--help"]"#).unwrap();
+    assert_eq!(*info.test_arg.unwrap(), &["clippy", "--help"]);
+}
+
+#[test]
+fn install_rustup_component_info_deserialize_missing_test_arg() {
+    let info: InstallRustupComponentInfo = toml::from_str(r#"rustup_component_name = "clippy-preview"
+                                                             binary = "cargo""#).unwrap();
+
+    assert_eq!(info.test_arg, None);
 }
 
 #[test]
@@ -368,12 +399,12 @@ fn install_crate_eq_different_rustup_component_info() {
     let first = InstallCrate::RustupComponentInfo(InstallRustupComponentInfo {
         rustup_component_name: "component1".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     });
     let second = InstallCrate::RustupComponentInfo(InstallRustupComponentInfo {
         rustup_component_name: "component2".to_string(),
         binary: Some("bin".to_string()),
-        test_arg: Some("--help".to_string()),
+        test_arg: Some(TestArg { inner: vec!["--help".to_string()] }),
     });
 
     assert!(first != second);


### PR DESCRIPTION
Fixes #252 

Still need to add some tests and docs.

This changes `InstallCrateInfo`'s `test_arg` to take either a string (as is currently allowed) or an array - by using a custom deserializer function. In other words, both of those rules are now allowed:

```toml
[tasks.install-mkisofs-rs]
install_crate = { crate_name = "mkisofs-rs", binary = "mkisofs-rs", test_arg = "--help" }

[tasks.install-cargo-travis]
install_crate = { crate_name = "cargo-travis", binary = "cargo", test_arg = ["doc-upload", "--help"] }
```