### PR TITLE
Add --out Xml to coverage-tarpaulin task

### DIFF
--- a/src/lib/Makefile.stable.toml
+++ b/src/lib/Makefile.stable.toml
@@ -798,7 +798,7 @@ category = "Test"
 [tasks.coverage-tarpaulin.linux]
 category = "Test"
 command = "cargo"
-args = ["tarpaulin"]
+args = ["tarpaulin", "--out", "Xml"]
 
 [tasks.post-coverage]
 category = "Test"


### PR DESCRIPTION
Fixes #274

Tarpaulin generates the required xml files, but only if asked to with --out Xml. See xd009642/tarpaulin#15