### PR TITLE
Use IndexMap::swap_remove instead of remove

### DIFF
--- a/src/lib/descriptor.rs
+++ b/src/lib/descriptor.rs
@@ -38,7 +38,7 @@ fn merge_env(
         let value_clone = value.clone();
 
         if merged.contains_key(&key_str) {
-            let base_value = merged.remove(&key_str).unwrap();
+            let base_value = merged.swap_remove(&key_str).unwrap();
 
             match (base_value, value_clone.clone()) {
                 (


### PR DESCRIPTION
The remove function is deprecated. Swap_remove should be used instead.

Cargo-make currently fails to compile without this change.

-----------------------

As a side-note, I think cargo-make should commit its Cargo.lock in the repo. The lack of a Cargo.lock means that cloning the repo and building might lead to compilation errors due to newer versions of the dependencies breaking the build (as is the case with index-map here).