### PR TITLE
Add minimal example for drone.io

### DIFF
--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -2378,6 +2378,19 @@ When working with workspaces, in order to run the ci-flow for each member and pa
   displayName: ci flow
 ```
 
+<a name="usage-ci-drone-io"></a>
+#### drone.io
+This is a minimal `.drone.yml` example for running the ci-flow task with the docker runner:
+
+```yaml
+pipeline:
+  ci-flow:
+    image: rust:1.38-slim
+    commands:
+    - cargo install --debug cargo-make
+    - cargo make ci-flow
+```
+
 <a name="usage-predefined-flows"></a>
 ### Predefined Flows
 The [default Makefile.toml](https://github.com/sagiegurari/cargo-make/blob/master/src/lib/Makefile.stable.toml) file comes with many predefined tasks and flows.<br>


### PR DESCRIPTION
This should fix #257 

I tried that configuration file in the `examples/workspace` project and it works.

I didn't add anything about cache because I'm not sure how well it would work when caching the `~/.cargo` folder, and right now I can try only the local runner, so no cache available.