### PR TITLE
Color configuration by environment variable

### DIFF
--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -2768,6 +2768,9 @@ The following example config.toml shows all possible options with their default 
 # The default log level if not defined by the --loglevel cli argument
 log_level = "info"
 
+# The default configuration whether output coloring is disabled
+disable_color = false
+
 # The default task name if no task was provided as part of the cargo-make invocation
 default_task_name = "default"
 

--- a/examples/cargo-make/config.toml
+++ b/examples/cargo-make/config.toml
@@ -1,4 +1,5 @@
 log_level = "error"
+disable_color = true
 default_task_name = "build"
 update_check_minimum_interval = "daily"
 search_project_root = true

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -189,7 +189,13 @@ fn run_for_args(
             .to_string()
     };
 
-    cli_args.disable_color = cmd_matches.is_present("no-color");
+    let default_disable_color = match global_config.disable_color {
+        Some(value) => value,
+        None => false,
+    };
+    cli_args.disable_color = cmd_matches.is_present("no-color")
+        || envmnt::is("CARGO_MAKE_DISABLE_COLOR")
+        || default_disable_color;
 
     cli_args.env_file = match cmd_matches.value_of("envfile") {
         Some(value) => Some(value.to_string()),

--- a/src/lib/cli_test.rs
+++ b/src/lib/cli_test.rs
@@ -370,6 +370,7 @@ fn run_for_args_with_global_config() {
     let mut global_config = GlobalConfig::new();
     global_config.log_level = Some("info".to_string());
     global_config.default_task_name = Some("empty".to_string());
+    global_config.disable_color = Some(true);
     let app = create_cli(&global_config, &"make".to_string(), true);
 
     let matches = app.get_matches_from(vec!["cargo", "make"]);

--- a/src/lib/logger.rs
+++ b/src/lib/logger.rs
@@ -128,6 +128,7 @@ pub(crate) fn init(options: &LoggerOptions) {
     let level_name_value = get_name_for_filter(&log_level);
 
     envmnt::set("CARGO_MAKE_LOG_LEVEL", &level_name_value);
+    envmnt::set_bool("CARGO_MAKE_DISABLE_COLOR", !color);
 
     let result = fern::Dispatch::new()
         .format(move |out, message, record| {

--- a/src/lib/logger_test.rs
+++ b/src/lib/logger_test.rs
@@ -170,3 +170,15 @@ fn create_error() {
 
     error!("test");
 }
+
+#[test]
+fn update_disable_color_env_var() {
+    envmnt::remove("CARGO_MAKE_DISABLE_COLOR");
+
+    init(&LoggerOptions {
+        level: "info".to_string(),
+        color: false,
+    });
+
+    assert!(envmnt::is("CARGO_MAKE_DISABLE_COLOR"));
+}

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -137,6 +137,8 @@ pub struct GlobalConfig {
     pub file_name: Option<String>,
     /// Default log level
     pub log_level: Option<String>,
+    /// Default output coloring
+    pub disable_color: Option<bool>,
     /// Default task name
     pub default_task_name: Option<String>,
     /// Update check minimum time from the previous check (always, daily, weekly, monthly)
@@ -151,6 +153,7 @@ impl GlobalConfig {
         GlobalConfig {
             file_name: None,
             log_level: None,
+            disable_color: None,
             default_task_name: None,
             update_check_minimum_interval: None,
             search_project_root: Some(false),

--- a/src/lib/types_test.rs
+++ b/src/lib/types_test.rs
@@ -42,6 +42,7 @@ fn global_config_new() {
     assert!(global_config.default_task_name.is_none());
     assert!(global_config.update_check_minimum_interval.is_none());
     assert!(!global_config.search_project_root.unwrap());
+    assert!(global_config.disable_color.is_none());
 }
 
 #[test]


### PR DESCRIPTION
This PR introduces a new environment variable `CARGO_MAKE_DISABLE_COLOR, which controls whether output is colorized. It works well with nested `cargo make`, e.g. workspace. Also, a new global configuration `disable_color` is added, which works like setting the env variable. These changes fix the following inconsistent behavior in a workspace (e.g. `example/workspace2`).

Before:
<img width="561" alt="cargo_make_before" src="https://user-images.githubusercontent.com/6158152/66251217-ccdb3f80-e788-11e9-88c0-8524e4f9666d.png">

after
<img width="552" alt="cargo_make_after" src="https://user-images.githubusercontent.com/6158152/66251219-cf3d9980-e788-11e9-9adb-bb1dfdcda17d.png">
