### PR TITLE
Add target triple.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1349,6 +1349,7 @@ In addition to manually setting environment variables, cargo-make will also auto
 * **CARGO_MAKE_RUST_TARGET_OS** - windows, macos, ios, linux, android, etc ... (see rust cfg feature)
 * **CARGO_MAKE_RUST_TARGET_POINTER_WIDTH** - 32, 64
 * **CARGO_MAKE_RUST_TARGET_VENDOR** - apple, pc, unknown
+* **CARGO_MAKE_RUST_TARGET_TRIPLE** - x86_64-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-msvc, etc ...
 * **CARGO_MAKE_CRATE_HAS_DEPENDENCIES** - Holds true/false based if there are dependencies defined in the Cargo.toml or not (defined as *false* if no Cargo.toml is found)
 * **CARGO_MAKE_CRATE_IS_WORKSPACE** - Holds true/false based if this is a workspace crate or not (defined even if no Cargo.toml is found)
 * **CARGO_MAKE_CRATE_WORKSPACE_MEMBERS** - Holds list of member paths (defined as empty value if no Cargo.toml is found)

--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -1253,6 +1253,7 @@ In addition to manually setting environment variables, cargo-make will also auto
 * **CARGO_MAKE_RUST_TARGET_OS** - windows, macos, ios, linux, android, etc ... (see rust cfg feature)
 * **CARGO_MAKE_RUST_TARGET_POINTER_WIDTH** - 32, 64
 * **CARGO_MAKE_RUST_TARGET_VENDOR** - apple, pc, unknown
+* **CARGO_MAKE_RUST_TARGET_TRIPLE** - x86_64-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-msvc, etc ...
 * **CARGO_MAKE_CRATE_HAS_DEPENDENCIES** - Holds true/false based if there are dependencies defined in the Cargo.toml or not (defined as *false* if no Cargo.toml is found)
 * **CARGO_MAKE_CRATE_IS_WORKSPACE** - Holds true/false based if this is a workspace crate or not (defined even if no Cargo.toml is found)
 * **CARGO_MAKE_CRATE_WORKSPACE_MEMBERS** - Holds list of member paths (defined as empty value if no Cargo.toml is found)

--- a/src/lib/Makefile.stable.toml
+++ b/src/lib/Makefile.stable.toml
@@ -831,6 +831,7 @@ echo "    Target Env: ${CARGO_MAKE_RUST_TARGET_ENV}"
 echo "    Target OS: ${CARGO_MAKE_RUST_TARGET_OS}"
 echo "    Pointer Width: ${CARGO_MAKE_RUST_TARGET_POINTER_WIDTH}"
 echo "    Target Vendor: ${CARGO_MAKE_RUST_TARGET_VENDOR}"
+echo "    Target Triple: ${CARGO_MAKE_RUST_TARGET_TRIPLE}"
 echo "*************************************"
 '''
 ]

--- a/src/lib/environment/mod.rs
+++ b/src/lib/environment/mod.rs
@@ -371,10 +371,7 @@ fn setup_env_for_rust() -> RustInfo {
         "CARGO_MAKE_RUST_TARGET_VENDOR",
         &rustinfo.target_vendor.unwrap_or("unknown".to_string()),
     );
-    envmnt::set(
-        "CARGO_MAKE_RUST_TARGET_TRIPLE",
-        &rustinfo.target_triple.unwrap_or("unknown".to_string()),
-    );
+    envmnt::set_optional("CARGO_MAKE_RUST_TARGET_TRIPLE", &rustinfo.target_triple);
 
     rust_info_clone
 }

--- a/src/lib/environment/mod.rs
+++ b/src/lib/environment/mod.rs
@@ -371,6 +371,10 @@ fn setup_env_for_rust() -> RustInfo {
         "CARGO_MAKE_RUST_TARGET_VENDOR",
         &rustinfo.target_vendor.unwrap_or("unknown".to_string()),
     );
+    envmnt::set(
+        "CARGO_MAKE_RUST_TARGET_TRIPLE",
+        &rustinfo.target_triple.unwrap_or("unknown".to_string()),
+    );
 
     rust_info_clone
 }

--- a/src/lib/environment/mod_test.rs
+++ b/src/lib/environment/mod_test.rs
@@ -1080,6 +1080,7 @@ fn setup_env_for_rust_simple_check() {
     envmnt::set("CARGO_MAKE_RUST_TARGET_OS", "EMPTY");
     envmnt::set("CARGO_MAKE_RUST_TARGET_POINTER_WIDTH", "EMPTY");
     envmnt::set("CARGO_MAKE_RUST_TARGET_VENDOR", "EMPTY");
+    envmnt::set("CARGO_MAKE_RUST_TARGET_TRIPLE", "EMPTY");
 
     assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_VERSION") == "EMPTY");
     assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL") == "EMPTY");
@@ -1088,6 +1089,7 @@ fn setup_env_for_rust_simple_check() {
     assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_TARGET_OS") == "EMPTY");
     assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_TARGET_POINTER_WIDTH") == "EMPTY");
     assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_TARGET_VENDOR") == "EMPTY");
+    assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_TARGET_TRIPLE") == "EMPTY");
 
     setup_env_for_rust();
 
@@ -1098,6 +1100,7 @@ fn setup_env_for_rust_simple_check() {
     assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_TARGET_OS") != "EMPTY");
     assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_TARGET_POINTER_WIDTH") != "EMPTY");
     assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_TARGET_VENDOR") != "EMPTY");
+    assert!(envmnt::get_or_panic("CARGO_MAKE_RUST_TARGET_TRIPLE") != "EMPTY");
 }
 
 #[test]


### PR DESCRIPTION
This adds a `CARGO_MAKE_RUST_TARGET_TRIPLE` environment variable, mainly because I'm sick of building it over and over by hand again.

Until now my main use case was building with `build-std`, which needs a defined `--target`, but I'm sure there are quite some use cases for this.

This relies on sagiegurari/rust_info#1, I thought this should be upstream, correct me if I should just implement it here.