### PR TITLE
Ensure that the specified rustup toolchain exists before using it

### DIFF
--- a/src/lib/toolchain.rs
+++ b/src/lib/toolchain.rs
@@ -8,12 +8,17 @@
 mod toolchain_test;
 
 use crate::types::CommandSpec;
+use std::process::{Command, Stdio};
 
 pub(crate) fn wrap_command(
     toolchain: &str,
     command: &str,
     args: &Option<Vec<String>>,
 ) -> CommandSpec {
+    if !has_toolchain(toolchain) {
+        error!("Missing toolchain {}! Please install it using rustup.", &toolchain);
+    }
+
     let mut rustup_args = vec![
         "run".to_string(),
         toolchain.to_string(),
@@ -33,4 +38,14 @@ pub(crate) fn wrap_command(
         command: "rustup".to_string(),
         args: Some(rustup_args),
     }
+}
+
+fn has_toolchain(toolchain: &str) -> bool {
+    Command::new("rustup")
+        .args(&["run", toolchain, "true"])
+        .stderr(Stdio::null())
+        .stdout(Stdio::null())
+        .status()
+        .expect("Failed to check rustup toolchain")
+        .success()
 }

--- a/src/lib/toolchain_test.rs
+++ b/src/lib/toolchain_test.rs
@@ -1,36 +1,46 @@
 use super::*;
+use envmnt;
+
+#[test]
+#[should_panic]
+fn wrap_command_invalid_toolchain() {
+    wrap_command("invalid-chain", "true", &None);
+}
 
 #[test]
 fn wrap_command_none_args() {
-    let output = wrap_command("mychain", "testcommand", &None);
+    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL");
+    let output = wrap_command(&channel, "true", &None);
 
     assert_eq!(output.command, "rustup".to_string());
 
     let args = output.args.unwrap();
     assert_eq!(args.len(), 3);
     assert_eq!(args[0], "run".to_string());
-    assert_eq!(args[1], "mychain".to_string());
-    assert_eq!(args[2], "testcommand".to_string());
+    assert_eq!(args[1], channel);
+    assert_eq!(args[2], "true".to_string());
 }
 
 #[test]
 fn wrap_command_empty_args() {
-    let output = wrap_command("mychain", "testcommand", &Some(vec![]));
+    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL");
+    let output = wrap_command(&channel, "true", &Some(vec![]));
 
     assert_eq!(output.command, "rustup".to_string());
 
     let args = output.args.unwrap();
     assert_eq!(args.len(), 3);
     assert_eq!(args[0], "run".to_string());
-    assert_eq!(args[1], "mychain".to_string());
-    assert_eq!(args[2], "testcommand".to_string());
+    assert_eq!(args[1], channel);
+    assert_eq!(args[2], "true".to_string());
 }
 
 #[test]
 fn wrap_command_with_args() {
+    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL");
     let output = wrap_command(
-        "mychain",
-        "testcommand",
+        &channel,
+        "true",
         &Some(vec!["echo".to_string(), "test".to_string()]),
     );
 
@@ -39,8 +49,8 @@ fn wrap_command_with_args() {
     let args = output.args.unwrap();
     assert_eq!(args.len(), 5);
     assert_eq!(args[0], "run".to_string());
-    assert_eq!(args[1], "mychain".to_string());
-    assert_eq!(args[2], "testcommand".to_string());
+    assert_eq!(args[1], channel);
+    assert_eq!(args[2], "true".to_string());
     assert_eq!(args[3], "echo".to_string());
     assert_eq!(args[4], "test".to_string());
 }


### PR DESCRIPTION
Given a config like this

    [tasks.test]
    command = "cargo"
    args = [ "build" ]
    toolchain = "alarm"

you get a fairly unintuitive error output like this:

```
[cargo-make] INFO - Running Task: test
[cargo-make] ERROR - Error while executing command, exit code: 1
[cargo-make] WARN - Build Failed.
```

This can be quite confusing especially for people who are new to a
project and might've missed installing the specified rustup toolchain
before building the project with `cargo-make`.

This patch ensures in the `toolchain`-subcrate that the toolchain
actually exists (by checking the exit-code of `rustup run <toolchain>
true`) before running the actual task. If the toolchain doesn't exist,
an error like this will be thrown:

```
[cargo-make] INFO - Running Task: test
[cargo-make] ERROR - Please install the toolchain alarm using rustup before building!
[cargo-make] WARN - Build Failed.
```