### PR TITLE
Display recursion-level like `make(1)`

### DIFF
--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -14,6 +14,7 @@ use crate::environment;
 use crate::logger;
 use crate::logger::LoggerOptions;
 use crate::profile;
+use crate::recursion_level;
 use crate::runner;
 use crate::types::{CliArgs, GlobalConfig};
 use crate::version;
@@ -28,13 +29,17 @@ static DEFAULT_TASK_NAME: &str = "default";
 static DEFAULT_OUTPUT_FORMAT: &str = "default";
 
 fn run(cli_args: CliArgs, global_config: &GlobalConfig) {
+    recursion_level::increase_level();
+
     logger::init(&LoggerOptions {
         level: cli_args.log_level.clone(),
         color: !cli_args.disable_color,
     });
 
-    info!("{} {}", &cli_args.command, &VERSION);
-    debug!("Written By {}", &AUTHOR);
+    if recursion_level::is_first_level() {
+        info!("{} {}", &cli_args.command, &VERSION);
+        debug!("Written By {}", &AUTHOR);
+    }
 
     debug!("Cli Args {:#?}", &cli_args);
     debug!("Global Configuration {:#?}", &global_config);

--- a/src/lib/logger.rs
+++ b/src/lib/logger.rs
@@ -8,6 +8,7 @@
 mod logger_test;
 
 use colored::*;
+use crate::recursion_level;
 use envmnt;
 use fern;
 use log::{Level, LevelFilter};
@@ -123,9 +124,12 @@ pub(crate) fn init(options: &LoggerOptions) {
     envmnt::set("CARGO_MAKE_LOG_LEVEL", &level_name_value);
     envmnt::set_bool("CARGO_MAKE_DISABLE_COLOR", !color);
 
+    let level = recursion_level::recursion_level();
+
     let result = fern::Dispatch::new()
         .format(move |out, message, record| {
             let name = env!("CARGO_PKG_NAME");
+
             let record_level = record.level();
 
             if cfg!(test) {
@@ -139,8 +143,8 @@ pub(crate) fn init(options: &LoggerOptions) {
             let record_level_fmt = get_formatted_log_level(&record_level, color);
 
             out.finish(format_args!(
-                "[{}] {} - {}",
-                &name_fmt, &record_level_fmt, &message
+                "[{}] {} {} - {}",
+                &name_fmt, level, &record_level_fmt, &message
             ));
 
             if record_level == Level::Error {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -157,6 +157,7 @@ mod io;
 mod legacy;
 mod logger;
 mod profile;
+mod recursion_level;
 mod runner;
 mod scriptengine;
 mod storage;

--- a/src/lib/recursion_level.rs
+++ b/src/lib/recursion_level.rs
@@ -1,0 +1,28 @@
+//! # recursion_level
+//!
+//! Utility functions to keep track of the recursion of cargo-make calls.
+//!
+
+#[cfg(test)]
+#[path = "./recursion_level_test.rs"]
+mod recursion_level_test;
+
+use envmnt;
+
+static RECURSION_ENV_VAR_NAME: &str = "CARGO_MAKE_INTERNAL_RECURSION";
+
+pub(crate) fn recursion_level() -> u32 {
+    envmnt::get_or(RECURSION_ENV_VAR_NAME, "0").parse().expect("failed to retrieve env var")
+}
+
+pub(crate) fn is_first_level() -> bool {
+    recursion_level() == 0
+}
+
+pub(crate) fn increase_level() {
+    envmnt::set(
+        RECURSION_ENV_VAR_NAME,
+        if envmnt::exists(RECURSION_ENV_VAR_NAME) { (recursion_level() + 1).to_string() }
+        else { "0".to_string() }
+    )
+}

--- a/src/lib/recursion_level_test.rs
+++ b/src/lib/recursion_level_test.rs
@@ -1,0 +1,23 @@
+use super::*;
+use envmnt;
+
+#[test]
+fn recursion_level_changes() {
+    // backup environment to avoid having conflicts if
+    // the test is run within `cargo-make`.
+    let rec_lvl = envmnt::get_or(RECURSION_ENV_VAR_NAME, "0");
+    envmnt::remove(RECURSION_ENV_VAR_NAME);
+
+    assert!(is_first_level());
+    assert_eq!(recursion_level(), 0);
+
+    increase_level(); // explicitly set to 0
+    increase_level();
+    assert!(!is_first_level());
+    assert_eq!(recursion_level(), 1);
+
+    increase_level();
+    assert_eq!(recursion_level(), 2);
+
+    envmnt::set(RECURSION_ENV_VAR_NAME, rec_lvl);
+}


### PR DESCRIPTION


* Added the env-var `CARGO_MAKE_INTERNAL_RECURSION` to keep track
  of recursive calls to `cargo-make`.

* General information like version of `cargo-make` will only be
  displayed at the first call.

* At the first recursion, the level will be shown by the logger.