### PR TITLE
Fix toolchain check on Windows

### DIFF
--- a/src/lib/toolchain.rs
+++ b/src/lib/toolchain.rs
@@ -59,7 +59,7 @@ pub(crate) fn wrap_command(
 
 fn has_toolchain(toolchain: &str) -> bool {
     Command::new("rustup")
-        .args(&["run", toolchain, "true"])
+        .args(&["run", toolchain, "rustc"])
         .stderr(Stdio::null())
         .stdout(Stdio::null())
         .status()


### PR DESCRIPTION
The toolchain check was previously using the `true` command to verify that the given toolchain existed, but the `true` command doesn't exist on Windows. This replaces that command with `rustc`.