### PR TITLE
Fix tasks.do-copy-apidocs

### DIFF
--- a/src/lib/descriptor/makefiles/mod_test.rs
+++ b/src/lib/descriptor/makefiles/mod_test.rs
@@ -130,7 +130,7 @@ fn makefile_coverage_kcov_test() {
 
 #[test]
 fn makefile_copy_apidocs_test() {
-    makefile_task_script_engine_test("do-copy-apidocs", EngineType::Shell2Batch);
+    makefile_task_script_engine_test("do-copy-apidocs", EngineType::Duckscript);
 }
 
 #[test]

--- a/src/lib/descriptor/makefiles/rust.toml
+++ b/src/lib/descriptor/makefiles/rust.toml
@@ -733,17 +733,37 @@ run_task = "do-copy-apidocs"
 description = "Copies the generated documentation to the docs/api directory."
 category = "Documentation"
 private = true
-script_runner = "@shell"
+script_runner = "@duckscript"
 script = [
 '''
-SOURCE_DIRECTORY=${CARGO_MAKE_DOCS_ROOT_FOLDER}/target/doc
-TARGET_DIRECTORY=${CARGO_MAKE_DOCS_ROOT_FOLDER}/docs/api/${CARGO_MAKE_DOCS_SUB_FOLDER}
+if is_empty "${CARGO_MAKE_DOCS_SUB_FOLDER}"
+    SRC_DIR= set ${CARGO_MAKE_DOCS_ROOT_FOLDER}
+else
+    SRC_DIR= set ${CARGO_MAKE_DOCS_ROOT_FOLDER}/${CARGO_MAKE_DOCS_SUB_FOLDER}
+end
 
-echo Source Directory: ${SOURCE_DIRECTORY}
-echo Target Directory: ${TARGET_DIRECTORY}
+if is_dir ${SRC_DIR}/target/${CARGO_MAKE_CRATE_TARGET_TRIPLE}/doc
+    SRC_DIR= set ${SRC_DIR}/target/${CARGO_MAKE_CRATE_TARGET_TRIPLE}/doc
+else
+    SRC_DIR= set ${SRC_DIR}/target/doc
+end
 
-mkdir -p ${TARGET_DIRECTORY}
-mv ${SOURCE_DIRECTORY}/* ${TARGET_DIRECTORY}
+if is_empty "${CARGO_MAKE_DOCS_SUB_FOLDER}"
+    DST_DIR= set ${CARGO_MAKE_DOCS_ROOT_FOLDER}/docs/api
+else
+    DST_DIR= set ${CARGO_MAKE_DOCS_ROOT_FOLDER}/docs/api/${CARGO_MAKE_DOCS_SUB_FOLDER}
+end
+
+echo Source Directory: ${SRC_DIR}
+echo Target Directory: ${DST_DIR}
+
+rm -r ${DST_DIR}
+mkdir ${DST_DIR}
+
+handle = glob_array ${SRC_DIR}/*
+for path in ${handle}
+    mv ${path} ${DST_DIR}
+end
 '''
 ]
 


### PR DESCRIPTION
1. It didn't work with a non-default target specified e.g. in
   `.cargo/config`
2. It didn't work with `CARGO_MAKE_CRATE_WORKSPACE_MEMBERS`
3. It didn't work when running `cargo make docs-flow` multiple times