### PR TITLE
Allow for explicit workspace flow in sub flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### v0.32.5
+
+* Allow for explicit workspace flow in sub flows
+
 ### v0.32.4 (2020-08-28)
 
 * Prevent multiple calls to cleanup task

--- a/src/lib/execution_plan_test.rs
+++ b/src/lib/execution_plan_test.rs
@@ -583,6 +583,31 @@ fn is_workspace_flow_true_in_task() {
 }
 
 #[test]
+fn is_workspace_flow_default_false_in_task_and_sub_flow() {
+    let mut crate_info = CrateInfo::new();
+    let members = vec![];
+    crate_info.workspace = Some(Workspace {
+        members: Some(members),
+        exclude: None,
+    });
+
+    let task = Task::new();
+
+    let mut config = Config {
+        config: ConfigSection::new(),
+        env_files: vec![],
+        env: IndexMap::new(),
+        env_scripts: vec![],
+        tasks: IndexMap::new(),
+    };
+    config.tasks.insert("test".to_string(), task);
+
+    let workspace_flow = is_workspace_flow(&config, "test", false, &crate_info, true);
+
+    assert!(!workspace_flow);
+}
+
+#[test]
 fn is_workspace_flow_true_in_task_and_sub_flow() {
     let mut crate_info = CrateInfo::new();
     let members = vec![];
@@ -593,6 +618,32 @@ fn is_workspace_flow_true_in_task_and_sub_flow() {
 
     let mut task = Task::new();
     task.workspace = Some(true);
+
+    let mut config = Config {
+        config: ConfigSection::new(),
+        env_files: vec![],
+        env: IndexMap::new(),
+        env_scripts: vec![],
+        tasks: IndexMap::new(),
+    };
+    config.tasks.insert("test".to_string(), task);
+
+    let workspace_flow = is_workspace_flow(&config, "test", false, &crate_info, true);
+
+    assert!(workspace_flow);
+}
+
+#[test]
+fn is_workspace_flow_false_in_task_and_sub_flow() {
+    let mut crate_info = CrateInfo::new();
+    let members = vec![];
+    crate_info.workspace = Some(Workspace {
+        members: Some(members),
+        exclude: None,
+    });
+
+    let mut task = Task::new();
+    task.workspace = Some(false);
 
     let mut config = Config {
         config: ConfigSection::new(),


### PR DESCRIPTION
Commit fa929b116f78 ("Fix workspace detection for sub flows") caused a
regression when having a root workspace with tasks that relies on each
member to define CARGO_MAKE_CARGO_BUILD_TEST_FLAGS with unique set of
features.

Determine if workspace flow is explicitly set in the task when planning
the execution and take this setting into account when running in a sub
flow.