### PR TITLE
Add toolchain to the namespace configuration.

### DIFF
--- a/src/lib/execution_plan.rs
+++ b/src/lib/execution_plan.rs
@@ -86,10 +86,6 @@ fn get_optional_normalized_task(config: &Config, name: &str, support_alias: bool
                     None => normalized_task,
                 };
 
-                if normalized_task.toolchain.is_none() && config.config.toolchain.is_some() {
-                    normalized_task.toolchain = config.config.toolchain.clone();
-                }
-
                 Some(normalized_task)
             }
             None => None,

--- a/src/lib/execution_plan.rs
+++ b/src/lib/execution_plan.rs
@@ -86,6 +86,10 @@ fn get_optional_normalized_task(config: &Config, name: &str, support_alias: bool
                     None => normalized_task,
                 };
 
+                if normalized_task.toolchain.is_none() && config.config.toolchain.is_some() {
+                    normalized_task.toolchain = config.config.toolchain.clone();
+                }
+
                 Some(normalized_task)
             }
             None => None,

--- a/src/lib/runner.rs
+++ b/src/lib/runner.rs
@@ -22,6 +22,7 @@ use crate::logger;
 use crate::profile;
 use crate::scriptengine;
 use crate::time_summary;
+use crate::toolchain;
 use crate::types::{
     CliArgs, Config, DeprecationInfo, EnvInfo, EnvValue, ExecutionPlan, FlowInfo, FlowState,
     RunTaskInfo, RunTaskName, RunTaskRoutingInfo, Step, Task, TaskWatchOptions,
@@ -353,12 +354,9 @@ pub(crate) fn run_task(flow_info: &FlowInfo, flow_state: &mut FlowState, step: &
             // modify step using env and functions
             let mut updated_step = functions::run(&step);
             updated_step = environment::expand_env(&updated_step);
+            toolchain::expand(flow_info, &mut updated_step);
 
-            if updated_step.config.toolchain.is_none()
-                && flow_info.config.config.toolchain.is_some()
-            {
-                updated_step.config.toolchain = flow_info.config.config.toolchain.clone();
-            }
+            debug!("Updated step definition {:#?}", &updated_step.config);
 
             let watch = should_watch(&step.config);
 

--- a/src/lib/runner.rs
+++ b/src/lib/runner.rs
@@ -354,6 +354,12 @@ pub(crate) fn run_task(flow_info: &FlowInfo, flow_state: &mut FlowState, step: &
             let mut updated_step = functions::run(&step);
             updated_step = environment::expand_env(&updated_step);
 
+            if updated_step.config.toolchain.is_none()
+                && flow_info.config.config.toolchain.is_some()
+            {
+                updated_step.config.toolchain = flow_info.config.config.toolchain.clone();
+            }
+
             let watch = should_watch(&step.config);
 
             if watch {

--- a/src/lib/toolchain.rs
+++ b/src/lib/toolchain.rs
@@ -7,7 +7,7 @@
 #[path = "./toolchain_test.rs"]
 mod toolchain_test;
 
-use crate::types::CommandSpec;
+use crate::types::{CommandSpec, FlowInfo, Step};
 use std::process::{Command, Stdio};
 
 #[cfg(test)]
@@ -65,4 +65,11 @@ fn has_toolchain(toolchain: &str) -> bool {
         .status()
         .expect("Failed to check rustup toolchain")
         .success()
+}
+
+pub(crate) fn expand(flow_info: &FlowInfo, step: &mut Step) {
+    println!("{:?}", flow_info.config.config.toolchain);
+    if step.config.toolchain.is_none() && flow_info.config.config.toolchain.is_some() {
+        step.config.toolchain = flow_info.config.config.toolchain.clone();
+    }
 }

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -1698,6 +1698,8 @@ pub struct ConfigSection {
     pub windows_load_script: Option<Vec<String>>,
     /// acts like load_script if runtime OS is Mac (takes precedence over load_script)
     pub mac_load_script: Option<Vec<String>>,
+    /// Toolchain to use for all tasks, this can be overwritten by individual tasks
+    pub toolchain: Option<String>,
 }
 
 impl ConfigSection {
@@ -1799,6 +1801,10 @@ impl ConfigSection {
 
         if extended.mac_load_script.is_some() {
             self.mac_load_script = extended.mac_load_script.clone();
+        }
+
+        if extended.toolchain.is_some() {
+            self.toolchain = extended.toolchain.clone();
         }
     }
 


### PR DESCRIPTION
This allows setting the toolchain version for alltasks in a common place, and still override it in individual tasks.

It's very useful to manage the toolchain for all tasks across a project. Freeing people from having to keep their local toolchains in sync with other environments, like CI.

This is an example of how I'm using it inside a large project:

```
[config]
    default_to_workspace = false
    toolchain = "nightly-2020-09-20"
```

This PR is missing tests and docs, so I'm creating it as a draft.

Signed-off-by: David Calavera <david.calavera@gmail.com>