### PR TITLE
Fix for env_files loading

### DIFF
--- a/src/lib/environment/mod.rs
+++ b/src/lib/environment/mod.rs
@@ -227,31 +227,32 @@ fn set_env_files_for_config(
 ) -> bool {
     let mut all_loaded = true;
     for env_file in env_files {
-        all_loaded = all_loaded
-            && match env_file {
-                EnvFile::Path(file) => load_env_file(Some(file)),
-                EnvFile::Info(info) => {
-                    let is_valid_profile = match info.profile {
-                        Some(profile_name) => {
-                            let current_profile_name = profile::get();
+        let loaded = match env_file {
+            EnvFile::Path(file) => load_env_file(Some(file)),
+            EnvFile::Info(info) => {
+                let is_valid_profile = match info.profile {
+                    Some(profile_name) => {
+                        let current_profile_name = profile::get();
 
-                            let found = match additional_profiles {
-                                Some(profiles) => profiles.contains(&profile_name),
-                                None => false,
-                            };
+                        let found = match additional_profiles {
+                            Some(profiles) => profiles.contains(&profile_name),
+                            None => false,
+                        };
 
-                            current_profile_name == profile_name || found
-                        }
-                        None => true,
-                    };
-
-                    if is_valid_profile {
-                        load_env_file_with_base_directory(Some(info.path), info.base_path)
-                    } else {
-                        false
+                        current_profile_name == profile_name || found
                     }
+                    None => true,
+                };
+
+                if is_valid_profile {
+                    load_env_file_with_base_directory(Some(info.path), info.base_path)
+                } else {
+                    false
                 }
             }
+        };
+
+        all_loaded = all_loaded && loaded;
     }
 
     all_loaded

--- a/src/lib/environment/mod_test.rs
+++ b/src/lib/environment/mod_test.rs
@@ -652,6 +652,45 @@ fn set_env_files_for_config_profile() {
 
 #[test]
 #[ignore]
+fn set_env_files_for_config_profile_inverse() {
+    let mut env = envmnt::parse_file("./src/lib/test/test_files/env.env").unwrap();
+    env.extend(envmnt::parse_file("./src/lib/test/test_files/profile.env").unwrap());
+    for (key, _) in env.clone().iter() {
+        envmnt::remove(&key);
+    }
+
+    assert!(!envmnt::exists("CARGO_MAKE_ENV_FILE_TEST1"));
+    assert!(!envmnt::exists("CARGO_MAKE_ENV_FILE_PROFILE_TEST1"));
+
+    profile::set("env_test1");
+
+    let loaded = set_env_files_for_config(
+        vec![
+            EnvFile::Info(EnvFileInfo {
+                path: "./test/test_files/env.env".to_string(),
+                base_path: Some("./src/lib".to_string()),
+                profile: Some("env_test2".to_string()),
+            }),
+            EnvFile::Info(EnvFileInfo {
+                path: "./test/test_files/profile.env".to_string(),
+                base_path: Some("./src/lib".to_string()),
+                profile: Some("env_test1".to_string()),
+            }),
+        ],
+        None,
+    );
+
+    assert!(!loaded);
+    assert!(!envmnt::exists("CARGO_MAKE_ENV_FILE_TEST1"));
+    assert!(envmnt::exists("CARGO_MAKE_ENV_FILE_PROFILE_TEST1"));
+
+    for (key, _) in env.iter() {
+        envmnt::remove(&key);
+    }
+}
+
+#[test]
+#[ignore]
 fn set_env_files_for_config_additional_profiles() {
     let mut env = envmnt::parse_file("./src/lib/test/test_files/env.env").unwrap();
     env.extend(envmnt::parse_file("./src/lib/test/test_files/profile.env").unwrap());


### PR DESCRIPTION
Hi,
i found out that when loading `env_files` with profiles , if a profile is not matched the loading process is interrupted and the eventual other files in the list are skipped.

In order to show this behaviour  i've created the test `set_env_files_for_config_profile_inverse ` by copying `set_env_files_for_config_profile` inverting the positions of the two files in the test.

I'm not sure if it's a wanted behaviour or a bug. In case of a bug in this PR there is the fix

Thanks :)