### PR TITLE
Provide more detailed error message when env-script fails

### DIFF
--- a/src/lib/environment/mod_test.rs
+++ b/src/lib/environment/mod_test.rs
@@ -942,10 +942,13 @@ fn setup_env_script() {
 
 #[test]
 fn evaluate_env_value_valid() {
-    let output = evaluate_env_value(&EnvValueScript {
-        script: vec!["echo script1".to_string()],
-        multi_line: None,
-    });
+    let output = evaluate_env_value(
+        "MY_ENV_SCRIPT_KEY",
+        &EnvValueScript {
+            script: vec!["echo script1".to_string()],
+            multi_line: None,
+        },
+    );
 
     assert_eq!(output, "script1".to_string());
 }
@@ -953,10 +956,13 @@ fn evaluate_env_value_valid() {
 #[test]
 #[cfg(target_os = "linux")]
 fn evaluate_env_value_empty() {
-    let output = evaluate_env_value(&EnvValueScript {
-        script: vec!["".to_string()],
-        multi_line: None,
-    });
+    let output = evaluate_env_value(
+        "MY_ENV_SCRIPT_KEY",
+        &EnvValueScript {
+            script: vec!["".to_string()],
+            multi_line: None,
+        },
+    );
 
     assert_eq!(output, "".to_string());
 }
@@ -964,28 +970,37 @@ fn evaluate_env_value_empty() {
 #[test]
 #[should_panic]
 fn evaluate_env_error() {
-    evaluate_env_value(&EnvValueScript {
-        script: vec!["exit 1".to_string()],
-        multi_line: None,
-    });
+    evaluate_env_value(
+        "MY_ENV_SCRIPT_KEY",
+        &EnvValueScript {
+            script: vec!["exit 1".to_string()],
+            multi_line: None,
+        },
+    );
 }
 
 #[test]
 fn evaluate_env_value_single_line() {
-    let output = evaluate_env_value(&EnvValueScript {
-        script: vec!["echo test".to_string()],
-        multi_line: Some(false),
-    });
+    let output = evaluate_env_value(
+        "MY_ENV_SCRIPT_KEY",
+        &EnvValueScript {
+            script: vec!["echo test".to_string()],
+            multi_line: Some(false),
+        },
+    );
 
     assert!(output.contains("test"));
 }
 
 #[test]
 fn evaluate_env_value_multi_line() {
-    let output = evaluate_env_value(&EnvValueScript {
-        script: vec!["echo 1\necho 2".to_string()],
-        multi_line: Some(true),
-    });
+    let output = evaluate_env_value(
+        "MY_ENV_SCRIPT_KEY",
+        &EnvValueScript {
+            script: vec!["echo 1\necho 2".to_string()],
+            multi_line: Some(true),
+        },
+    );
 
     assert!(output.contains("1"));
     assert!(output.contains("2"));
@@ -994,10 +1009,13 @@ fn evaluate_env_value_multi_line() {
 #[test]
 #[cfg(target_os = "linux")]
 fn evaluate_env_value_multi_line_linux() {
-    let output = evaluate_env_value(&EnvValueScript {
-        script: vec!["echo 1\necho 2".to_string()],
-        multi_line: Some(true),
-    });
+    let output = evaluate_env_value(
+        "MY_ENV_SCRIPT_KEY",
+        &EnvValueScript {
+            script: vec!["echo 1\necho 2".to_string()],
+            multi_line: Some(true),
+        },
+    );
 
     assert!(output.contains("1"));
     assert!(output.contains("2"));


### PR DESCRIPTION
There is limited information given in the error output when an
env-script return a non-zero exit code, which can be quite confusing as
there is no context of where it failed (unless verbose output is turned
on).

Avoid confusion by providing more context about the environment when the
script fails.

BEFORE:
 > cargo make
 [cargo-make] INFO - cargo make 0.32.5
 [cargo-make] ERROR - Error while executing command, exit code: 128
 [cargo-make] WARN - Build Failed.

AFTER:
 > cargo make
 [cargo-make] INFO - cargo make 0.32.5
 [cargo-make] ERROR - Error while evaluating script for env: GIT_ROOT, exit code: 128
 script: [
     "git rev-parse --show-toplevel",
 ]
 stdout: ""
 stderr: "fatal: not a git repository (or any of the parent directories): .git
 "
 [cargo-make] WARN - Build Failed.