### PR TITLE
Cargo.toml: Bump the version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-make"
-version = "0.32.5"
+version = "0.32.6"
 authors = ["Sagie Gur-Ari <sagiegurari@gmail.com>"]
 description = "Rust task runner and build tool."
 license = "Apache-2.0"


### PR DESCRIPTION
This is submitted to avoid issues like:

```console
kreyren@leonid:~/Repositories/kreyrock$ cargo install cargo-make --branch "0.32.6" --version 0.32.6 --force --git https://github.com/sagiegurari/cargo-make.git
    Updating git repository `https://github.com/sagiegurari/cargo-make.git`
error: could not find `cargo-make` in https://github.com/sagiegurari/cargo-make.git?branch=0.32.6 with version `=0.32.6`
kreyren@leonid:~/Repositories/kreyrock$ cargo install cargo-make --branch "0.32.6" --force --git https://github.com/sagiegurari/cargo-make.git
    Updating git repository `https://github.com/sagiegurari/cargo-make.git`
  Installing cargo-make v0.32.5 (https://github.com/sagiegurari/cargo-make.git?branch=0.32.6#09473f98)
    Updating crates.io index
  Downloaded ci_info v0.11.0
...
```

