### PR TITLE
Improve logs when failing to parse external descriptor

### DIFF
--- a/src/lib/descriptor/mod.rs
+++ b/src/lib/descriptor/mod.rs
@@ -375,7 +375,16 @@ fn load_external_descriptor(
 
         let mut file_config: ExternalConfig = match toml::from_str(&external_descriptor) {
             Ok(value) => value,
-            Err(error) => panic!("Unable to parse external descriptor, {}", error),
+            Err(error) => {
+                error!(
+                    "Unable to parse external file: {:#?}, {}",
+                    &file_path, error
+                );
+                panic!(
+                    "Unable to parse external file: {:#?}, {}",
+                    &file_path, error
+                );
+            }
         };
         debug!("Loaded external config: {:#?}", &file_config);
 


### PR DESCRIPTION
cargo-make currently panics when failing to parse an external
descriptor. The panic log is quite confusing since it doesn't tell
which file that caused the error.

Log the name of the file that couldn't be parsed. Add a corresponding
error log before the panic call to force a clean exit(1) instead of
panic.

BEFORE:
$ cargo make
[cargo-make] INFO - cargo make 0.32.7
thread 'main' panicked at 'Unable to parse external descriptor,
  unexpected character found: `\\` at line 1 column 1',
  src/lib/descriptor/mod.rs:378:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

AFTER:
$ cargo make
[cargo-make] INFO - cargo make 0.32.7
[cargo-make] ERROR - Unable to parse external file: "./test.toml",
  unexpected character found: `\\` at line 1 column 1
[cargo-make] WARN - Build Failed.