### PR TITLE
Allow "=" in ENV value from CLI

### DIFF
--- a/src/lib/cli_test.rs
+++ b/src/lib/cli_test.rs
@@ -441,7 +441,7 @@ fn run_for_args_set_env_values() {
         "--env",
         "ENV1_TEST=TEST1",
         "--env",
-        "ENV2_TEST=TEST2",
+        "ENV2_TEST=TEST2a=TEST2b",
         "-e",
         "ENV3_TEST=TEST3",
         "--verbose",
@@ -453,7 +453,7 @@ fn run_for_args_set_env_values() {
     run_for_args(matches, &global_config, &"make".to_string(), true);
 
     assert_eq!(envmnt::get_or_panic("ENV1_TEST"), "TEST1");
-    assert_eq!(envmnt::get_or_panic("ENV2_TEST"), "TEST2");
+    assert_eq!(envmnt::get_or_panic("ENV2_TEST"), "TEST2a=TEST2b");
     assert_eq!(envmnt::get_or_panic("ENV3_TEST"), "TEST3");
 }
 

--- a/src/lib/descriptor/mod.rs
+++ b/src/lib/descriptor/mod.rs
@@ -511,14 +511,11 @@ fn merge_base_config_and_external_config(
             let mut cli_env = IndexMap::new();
 
             for env_pair in &values {
-                let env_part: Vec<&str> = env_pair.split('=').collect();
                 debug!("Checking env pair: {}", &env_pair);
+                let env_parts: Option<(&str, &str)> = split_once(env_pair, '=');
 
-                if env_part.len() == 2 {
-                    cli_env.insert(
-                        env_part[0].to_string(),
-                        EnvValue::Value(env_part[1].to_string()),
-                    );
+                if let Some((key, value)) = env_parts {
+                    cli_env.insert(key.to_string(), EnvValue::Value(value.to_string()));
                 }
             }
 
@@ -539,6 +536,13 @@ fn merge_base_config_and_external_config(
         env_scripts,
         tasks: all_tasks,
     }
+}
+
+fn split_once(value: &str, delimiter: char) -> Option<(&str, &str)> {
+    let mut parts = value.splitn(2, delimiter);
+    let part1 = parts.next()?;
+    let part2 = parts.next()?;
+    Some((part1, part2))
 }
 
 /// Loads the tasks descriptor.<br>


### PR DESCRIPTION
Currently running `cargo make -e RUST_LOG="my_crate=debug` fails to set the `RUST_LOG` variable inside the makefile.

This updates the ENV parsing to allow for this.