### PR TITLE
Align right sharp of new version notification

### DIFF
--- a/src/lib/version.rs
+++ b/src/lib/version.rs
@@ -100,17 +100,13 @@ pub(crate) fn is_newer_found(version_string: &str) -> bool {
 }
 
 fn print_notification(latest_string: &str) {
-    let pad = 48 - VERSION.chars().count() - latest_string.chars().count();
-    let pad_left = " ".repeat(pad / 2);
-    let pad_right = " ".repeat(pad / 2 + (if pad % 2 == 0 { 0 } else { 1 }));
-
     warn!("#####################################################################");
     warn!("#                                                                   #");
     warn!("#                                                                   #");
     warn!("#                  NEW CARGO-MAKE VERSION FOUND!!!                  #");
     warn!(
-        "#{}Current: {}, Latest: {}{}#",
-        pad_left, VERSION, latest_string, pad_right
+        "#{:^67}#",
+        format!("Current: {}, Latest: {}", VERSION, latest_string)
     );
     warn!("#    Run 'cargo install --force cargo-make' to get latest version   #");
     warn!("#                                                                   #");

--- a/src/lib/version.rs
+++ b/src/lib/version.rs
@@ -100,13 +100,17 @@ pub(crate) fn is_newer_found(version_string: &str) -> bool {
 }
 
 fn print_notification(latest_string: &str) {
+    let pad = 48 - VERSION.chars().count() - latest_string.chars().count();
+    let pad_left = " ".repeat(pad / 2);
+    let pad_right = " ".repeat(pad / 2 + (if pad % 2 == 0 { 0 } else { 1 }));
+
     warn!("#####################################################################");
     warn!("#                                                                   #");
     warn!("#                                                                   #");
     warn!("#                  NEW CARGO-MAKE VERSION FOUND!!!                  #");
     warn!(
-        "#                  Current: {}, Latest: {}\t\t\t#",
-        VERSION, latest_string
+        "#{}Current: {}, Latest: {}{}#",
+        pad_left, VERSION, latest_string, pad_right
     );
     warn!("#    Run 'cargo install --force cargo-make' to get latest version   #");
     warn!("#                                                                   #");


### PR DESCRIPTION
The right-hand sharp in the line containing "Current" and "Latest" was not vertically aligned in some case. It is now centered by calculating the number of white space characters on the left and right.

Let's show this in a temporary test just for visual confirmation.
`src/lib/version.rs` (In this example, `warn!` is set to `println!` temporally in order to see its output):

```rust
fn print_notification(latest_string: &str) {
    let pad = 48 - VERSION.chars().count() - latest_string.chars().count();
    let pad_left = " ".repeat(pad / 2);
    let pad_right = " ".repeat(pad / 2 + (if pad % 2 == 0 { 0 } else { 1 }));

    println!("#####################################################################");
    println!("#                                                                   #");
    println!("#                                                                   #");
    println!("#                  NEW CARGO-MAKE VERSION FOUND!!!                  #");
    println!(
        "#{}Current: {}, Latest: {}{}#",
        pad_left, VERSION, latest_string, pad_right
    );
    println!("#    Run 'cargo install --force cargo-make' to get latest version   #");
    println!("#                                                                   #");
    println!("#                                                                   #");
    println!("#####################################################################");
}

#[test]
fn test_print_notification0() {
    print_notification("<THIS_IS_LATEST_STRING>");
}

#[test]
fn test_print_notification1() {
    print_notification("<THIS_IS_LATEST_STRING!>");
}
```

then `$ cargo test test_print_notification0 -- --nocapture` will output

```
#####################################################################
#                                                                   #
#                                                                   #
#                  NEW CARGO-MAKE VERSION FOUND!!!                  #
#         Current: 0.32.13, Latest: <THIS_IS_LATEST_STRING>         #
#    Run 'cargo install --force cargo-make' to get latest version   #
#                                                                   #
#                                                                   #
#####################################################################
```

and `$ cargo test test_print_notification1 -- --nocapture` will output

```
#####################################################################
#                                                                   #
#                                                                   #
#                  NEW CARGO-MAKE VERSION FOUND!!!                  #
#        Current: 0.32.13, Latest: <THIS_IS_LATEST_STRING!>         #
#    Run 'cargo install --force cargo-make' to get latest version   #
#                                                                   #
#                                                                   #
#####################################################################
```

The difference between test cases `*0` and `*1` is whether the length of the argument string is odd or even.