### PR TITLE
Minor change: Use "args" where there is more than one "arg"

### DIFF
--- a/src/lib/command.rs
+++ b/src/lib/command.rs
@@ -161,9 +161,7 @@ pub(crate) fn run_command_get_output(
 
     match *args {
         Some(ref args_vec) => {
-            for arg in args_vec.iter() {
-                command.arg(arg);
-            }
+            command.args(args_vec);
         }
         None => debug!("No command args defined."),
     };

--- a/src/lib/installer/cargo_plugin_installer.rs
+++ b/src/lib/installer/cargo_plugin_installer.rs
@@ -20,11 +20,7 @@ fn is_crate_installed(toolchain: &Option<String>, crate_name: &str) -> bool {
         Some(ref toolchain_string) => {
             let command_spec = wrap_command(toolchain_string, "cargo", &None);
             let mut cmd = Command::new(command_spec.command);
-
-            let args_vec = command_spec.args.unwrap();
-            for arg in args_vec.iter() {
-                cmd.arg(arg);
-            }
+            cmd.args(command_spec.args.unwrap());
 
             cmd
         }

--- a/src/lib/installer/rustup_component_installer.rs
+++ b/src/lib/installer/rustup_component_installer.rs
@@ -17,11 +17,7 @@ pub(crate) fn is_installed(toolchain: &Option<String>, binary: &str, test_args: 
         Some(ref toolchain_string) => {
             let command_spec = wrap_command(toolchain_string, binary, &None);
             let mut cmd = Command::new(command_spec.command);
-
-            let args_vec = command_spec.args.unwrap();
-            for arg in args_vec.iter() {
-                cmd.arg(arg);
-            }
+            cmd.args(command_spec.args.unwrap());
 
             cmd
         }

--- a/src/lib/version.rs
+++ b/src/lib/version.rs
@@ -32,8 +32,7 @@ fn get_version_from_output(line: &str) -> Option<String> {
 
 fn get_latest_version() -> Option<String> {
     let result = Command::new("cargo")
-        .arg("search")
-        .arg("cargo-make")
+        .args(&["search", "cargo-make"])
         .output();
 
     match result {

--- a/src/lib/version.rs
+++ b/src/lib/version.rs
@@ -32,7 +32,8 @@ fn get_version_from_output(line: &str) -> Option<String> {
 
 fn get_latest_version() -> Option<String> {
     let result = Command::new("cargo")
-        .args(&["search", "cargo-make"])
+        .arg("search")
+        .arg("cargo-make")
         .output();
 
     match result {


### PR DESCRIPTION
Replaced [`arg`](https://doc.rust-lang.org/std/process/struct.Command.html#method.arg)s with [`args`](https://doc.rust-lang.org/std/process/struct.Command.html#method.args).
This commit is not a bug fix.
