### PR TITLE
Fix makers formatting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,3 +22,8 @@ cargo make ci-flow
 ````
 
 * There are many automatic unit tests as part of the library which provide full coverage of the functionality.<br>Any fix/enhancement must come with a set of tests to ensure it's working well.
+
+- _For Windows users_: You need to allow to run PowerShell scripts (see [About Execution Policies](https:/go.microsoft.com/fwlink/?LinkID=135170) for more info). Run in PS:
+    ```ps
+    Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser
+    ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ serde_ignored = "^0.1"
 shell2batch = "^0.4.2"
 toml = "^0.5"
 
+[target.'cfg(windows)'.dependencies]
+ansi_term = "0.12.1"
+
 [dev-dependencies]
 rusty-hook = "^0.11"
 

--- a/src/lib/cache.rs
+++ b/src/lib/cache.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./cache_test.rs"]
+#[path = "cache_test.rs"]
 mod cache_test;
 
 use crate::storage;

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./cli_test.rs"]
+#[path = "cli_test.rs"]
 mod cli_test;
 
 use crate::cli_commands;

--- a/src/lib/cli_commands/diff_steps.rs
+++ b/src/lib/cli_commands/diff_steps.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./diff_steps_test.rs"]
+#[path = "diff_steps_test.rs"]
 mod diff_steps_test;
 
 use crate::command;

--- a/src/lib/cli_commands/list_steps.rs
+++ b/src/lib/cli_commands/list_steps.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./list_steps_test.rs"]
+#[path = "list_steps_test.rs"]
 mod list_steps_test;
 
 use crate::execution_plan;

--- a/src/lib/cli_commands/print_steps.rs
+++ b/src/lib/cli_commands/print_steps.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./print_steps_test.rs"]
+#[path = "print_steps_test.rs"]
 mod print_steps_test;
 
 use crate::execution_plan::create as create_execution_plan;

--- a/src/lib/command.rs
+++ b/src/lib/command.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./command_test.rs"]
+#[path = "command_test.rs"]
 mod command_test;
 
 use crate::logger;

--- a/src/lib/condition.rs
+++ b/src/lib/condition.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./condition_test.rs"]
+#[path = "condition_test.rs"]
 mod condition_test;
 
 use crate::command;

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./config_test.rs"]
+#[path = "config_test.rs"]
 mod config_test;
 
 use crate::storage;

--- a/src/lib/descriptor/cargo_alias.rs
+++ b/src/lib/descriptor/cargo_alias.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./cargo_alias_test.rs"]
+#[path = "cargo_alias_test.rs"]
 mod cargo_alias_test;
 
 use crate::io;

--- a/src/lib/descriptor/descriptor_deserializer.rs
+++ b/src/lib/descriptor/descriptor_deserializer.rs
@@ -3,7 +3,7 @@
 //! Deserializes and validates the configs.
 
 #[cfg(test)]
-#[path = "./descriptor_deserializer_test.rs"]
+#[path = "descriptor_deserializer_test.rs"]
 mod descriptor_deserializer_test;
 
 use crate::types::{Config, ExternalConfig};

--- a/src/lib/descriptor/makefiles/mod.rs
+++ b/src/lib/descriptor/makefiles/mod.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./mod_test.rs"]
+#[path = "mod_test.rs"]
 mod mod_test;
 
 pub(crate) static BASE: &str = include_str!("base.toml");

--- a/src/lib/descriptor/mod.rs
+++ b/src/lib/descriptor/mod.rs
@@ -7,7 +7,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./mod_test.rs"]
+#[path = "mod_test.rs"]
 mod mod_test;
 
 mod cargo_alias;

--- a/src/lib/environment/crateinfo.rs
+++ b/src/lib/environment/crateinfo.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./crateinfo_test.rs"]
+#[path = "crateinfo_test.rs"]
 mod crateinfo_test;
 
 use crate::command;

--- a/src/lib/environment/mod.rs
+++ b/src/lib/environment/mod.rs
@@ -6,7 +6,7 @@
 pub(crate) mod crateinfo;
 
 #[cfg(test)]
-#[path = "./mod_test.rs"]
+#[path = "mod_test.rs"]
 mod mod_test;
 
 use crate::command;

--- a/src/lib/execution_plan.rs
+++ b/src/lib/execution_plan.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./execution_plan_test.rs"]
+#[path = "execution_plan_test.rs"]
 mod execution_plan_test;
 
 use crate::environment;

--- a/src/lib/functions/decode_func.rs
+++ b/src/lib/functions/decode_func.rs
@@ -6,7 +6,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./decode_func_test.rs"]
+#[path = "decode_func_test.rs"]
 mod decode_func_test;
 
 use crate::environment;

--- a/src/lib/functions/getat_func.rs
+++ b/src/lib/functions/getat_func.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./getat_func_test.rs"]
+#[path = "getat_func_test.rs"]
 mod getat_func_test;
 
 use envmnt;

--- a/src/lib/functions/mod.rs
+++ b/src/lib/functions/mod.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./mod_test.rs"]
+#[path = "mod_test.rs"]
 mod mod_test;
 
 mod decode_func;

--- a/src/lib/functions/remove_empty_func.rs
+++ b/src/lib/functions/remove_empty_func.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./remove_empty_func_test.rs"]
+#[path = "remove_empty_func_test.rs"]
 mod remove_empty_func_test;
 
 use envmnt;

--- a/src/lib/functions/split_func.rs
+++ b/src/lib/functions/split_func.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./split_func_test.rs"]
+#[path = "split_func_test.rs"]
 mod split_func_test;
 
 use envmnt;

--- a/src/lib/functions/trim_func.rs
+++ b/src/lib/functions/trim_func.rs
@@ -5,7 +5,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./trim_func_test.rs"]
+#[path = "trim_func_test.rs"]
 mod trim_func_test;
 
 use envmnt;

--- a/src/lib/installer/cargo_plugin_installer.rs
+++ b/src/lib/installer/cargo_plugin_installer.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./cargo_plugin_installer_test.rs"]
+#[path = "cargo_plugin_installer_test.rs"]
 mod cargo_plugin_installer_test;
 
 use crate::command;

--- a/src/lib/installer/crate_installer.rs
+++ b/src/lib/installer/crate_installer.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./crate_installer_test.rs"]
+#[path = "crate_installer_test.rs"]
 mod crate_installer_test;
 
 use crate::command;

--- a/src/lib/installer/crate_version_check.rs
+++ b/src/lib/installer/crate_version_check.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./crate_version_check_test.rs"]
+#[path = "crate_version_check_test.rs"]
 mod crate_version_check_test;
 
 use dirs_next;

--- a/src/lib/installer/mod.rs
+++ b/src/lib/installer/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod crate_version_check;
 pub(crate) mod rustup_component_installer;
 
 #[cfg(test)]
-#[path = "./mod_test.rs"]
+#[path = "mod_test.rs"]
 mod mod_test;
 
 use crate::scriptengine;

--- a/src/lib/installer/rustup_component_installer.rs
+++ b/src/lib/installer/rustup_component_installer.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./rustup_component_installer_test.rs"]
+#[path = "rustup_component_installer_test.rs"]
 mod rustup_component_installer_test;
 
 use crate::command;

--- a/src/lib/io.rs
+++ b/src/lib/io.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./io_test.rs"]
+#[path = "io_test.rs"]
 mod io_test;
 
 use fsio::file::modify_file;

--- a/src/lib/legacy.rs
+++ b/src/lib/legacy.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./legacy_test.rs"]
+#[path = "legacy_test.rs"]
 mod legacy_test;
 
 use dirs_next;

--- a/src/lib/logger.rs
+++ b/src/lib/logger.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./logger_test.rs"]
+#[path = "logger_test.rs"]
 mod logger_test;
 
 use crate::recursion_level;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -195,5 +195,9 @@ mod version;
 
 /// Handles the command line arguments and executes the runner.
 pub fn run_cli(command_name: String, sub_command: bool) {
+    #[cfg(windows)]
+    if let Err(err) = ansi_term::enable_ansi_support() {
+        eprintln!("error enabling ANSI support: {:?}", err);
+    }
     cli::run_cli(command_name, sub_command)
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -158,6 +158,10 @@
 //! [Apache 2](https://github.com/sagiegurari/cargo-make/blob/master/LICENSE) open source license.
 //!
 
+// Dependencies used in the binary `makers`:
+#[cfg(windows)]
+use ansi_term as _;
+
 #[macro_use]
 extern crate log;
 #[macro_use]
@@ -195,9 +199,5 @@ mod version;
 
 /// Handles the command line arguments and executes the runner.
 pub fn run_cli(command_name: String, sub_command: bool) {
-    #[cfg(windows)]
-    if let Err(err) = ansi_term::enable_ansi_support() {
-        eprintln!("error enabling ANSI support: {:?}", err);
-    }
     cli::run_cli(command_name, sub_command)
 }

--- a/src/lib/profile.rs
+++ b/src/lib/profile.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./profile_test.rs"]
+#[path = "profile_test.rs"]
 mod profile_test;
 
 use envmnt;

--- a/src/lib/proxy_task.rs
+++ b/src/lib/proxy_task.rs
@@ -3,7 +3,7 @@ use std::env;
 use crate::{logger, profile, types::Task};
 
 #[cfg(test)]
-#[path = "./proxy_task_test.rs"]
+#[path = "proxy_task_test.rs"]
 mod proxy_task_test;
 
 pub(crate) fn create_proxy_task(

--- a/src/lib/recursion_level.rs
+++ b/src/lib/recursion_level.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./recursion_level_test.rs"]
+#[path = "recursion_level_test.rs"]
 mod recursion_level_test;
 
 use envmnt;

--- a/src/lib/runner.rs
+++ b/src/lib/runner.rs
@@ -9,7 +9,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./runner_test.rs"]
+#[path = "runner_test.rs"]
 mod runner_test;
 
 use crate::command;

--- a/src/lib/scriptengine/duck_script/mod.rs
+++ b/src/lib/scriptengine/duck_script/mod.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./mod_test.rs"]
+#[path = "mod_test.rs"]
 mod mod_test;
 
 mod sdk;

--- a/src/lib/scriptengine/generic_script.rs
+++ b/src/lib/scriptengine/generic_script.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./generic_script_test.rs"]
+#[path = "generic_script_test.rs"]
 mod generic_script_test;
 
 use crate::command;

--- a/src/lib/scriptengine/mod.rs
+++ b/src/lib/scriptengine/mod.rs
@@ -12,7 +12,7 @@ mod shebang_script;
 mod shell_to_batch;
 
 #[cfg(test)]
-#[path = "./mod_test.rs"]
+#[path = "mod_test.rs"]
 mod mod_test;
 
 use crate::environment;

--- a/src/lib/scriptengine/os_script.rs
+++ b/src/lib/scriptengine/os_script.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./os_script_test.rs"]
+#[path = "os_script_test.rs"]
 mod os_script_test;
 
 use crate::command;

--- a/src/lib/scriptengine/rsscript.rs
+++ b/src/lib/scriptengine/rsscript.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./rsscript_test.rs"]
+#[path = "rsscript_test.rs"]
 mod rsscript_test;
 
 use crate::command;

--- a/src/lib/scriptengine/script_utils.rs
+++ b/src/lib/scriptengine/script_utils.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./script_utils_test.rs"]
+#[path = "script_utils_test.rs"]
 mod script_utils_test;
 
 use crate::io;

--- a/src/lib/scriptengine/shebang_script.rs
+++ b/src/lib/scriptengine/shebang_script.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./shebang_script_test.rs"]
+#[path = "shebang_script_test.rs"]
 mod shebang_script_test;
 
 use crate::scriptengine::generic_script;

--- a/src/lib/scriptengine/shell_to_batch.rs
+++ b/src/lib/scriptengine/shell_to_batch.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./shell_to_batch_test.rs"]
+#[path = "shell_to_batch_test.rs"]
 mod shell_to_batch_test;
 
 use crate::command;

--- a/src/lib/storage.rs
+++ b/src/lib/storage.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./storage_test.rs"]
+#[path = "storage_test.rs"]
 mod storage_test;
 
 use crate::legacy;

--- a/src/lib/toolchain.rs
+++ b/src/lib/toolchain.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./toolchain_test.rs"]
+#[path = "toolchain_test.rs"]
 mod toolchain_test;
 
 use crate::types::CommandSpec;

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -4,7 +4,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./types_test.rs"]
+#[path = "types_test.rs"]
 mod types_test;
 
 use crate::legacy;

--- a/src/lib/version.rs
+++ b/src/lib/version.rs
@@ -5,7 +5,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./version_test.rs"]
+#[path = "version_test.rs"]
 mod version_test;
 
 use crate::cache;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./main_test.rs"]
+#[path = "main_test.rs"]
 mod main_test;
 
 fn get_name() -> String {

--- a/src/makers.rs
+++ b/src/makers.rs
@@ -13,7 +13,7 @@
 //!
 
 #[cfg(test)]
-#[path = "./makers_test.rs"]
+#[path = "makers_test.rs"]
 mod makers_test;
 
 fn get_name() -> String {

--- a/src/makers.rs
+++ b/src/makers.rs
@@ -21,6 +21,8 @@ fn get_name() -> String {
 }
 
 fn main() {
+    #[cfg(windows)]
+    let _ = ansi_term::enable_ansi_support();
     let name = get_name();
     cli::run_cli(name, false);
 }


### PR DESCRIPTION
Fixes #533 

There are two commits, the first fixes the issue, the second one fixes `cargo make ci-flow` on Windows.

The reason why formatting works when you run `makers` indirectly (through `cargo run` or `cargo make`) is that `cargo` use a special print function: https://github.com/rust-lang/cargo/blob/e4aebf0a039ca3787f3ce98a9d469a3187f83706/src/cargo/core/shell.rs#L327-L340 with Windows-only code. _Note:_ There are multiple Unix/Windows "hacks" in the linked file to make the shell work as expected.

Another way is to enable ANSI support globally, just like Trunk or other apps do it. This approach has been used in this PR.  We need to call a native API to enable it: https://github.com/ogham/rust-ansi-term/blob/ff7eba98d55ad609c7fcc8c7bb0859b37c7545cc/src/windows.rs