### PR TITLE
Allow leading hyphens for arguments

### DIFF
--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -18,7 +18,7 @@ use crate::recursion_level;
 use crate::runner;
 use crate::types::{CliArgs, GlobalConfig};
 use crate::version;
-use clap::{App, Arg, ArgMatches, SubCommand};
+use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 static AUTHOR: &str = env!("CARGO_PKG_AUTHORS");
@@ -283,6 +283,7 @@ fn create_cli<'a, 'b>(
         .version(VERSION)
         .author(AUTHOR)
         .about(DESCRIPTION)
+        .setting(AppSettings::AllowLeadingHyphen)
         .arg(
             Arg::with_name("makefile")
                 .long("--makefile")


### PR DESCRIPTION
Fixes https://github.com/sagiegurari/cargo-make/issues/534

This is one-line change, ignore the first two commits, I'll rebase it once https://github.com/sagiegurari/cargo-make/pull/535 is merged.

This change allows to pass hyphenated arguments to tasks - e.g. `makers my_task arg1 -arg2`.

There are two ways to make it work:
1. Allow hyphenated args globally with [AppSettings::AllowLeadingHyphen](https://docs.rs/clap/2.33.3/clap/enum.AppSettings.html#variant.AllowLeadingHyphen)
2. Call [Arg::allow_hyphen_values](https://docs.rs/clap/2.33.3/clap/struct.Arg.html#method.allow_hyphen_values) on `Arg::with_name("TASK_ARGS")`

The second option doesn't work (I don't know why) so I've chosen the first option in this PR. 
_Note:_ There are some warnings in the related doc comments. They look acceptable for me, but I recommend to look at them, maybe you'll find some surprising edge-cases that I don't see.