### PR TITLE
Implement detailed toolchain specifier

### DIFF
--- a/src/lib/command_test.rs
+++ b/src/lib/command_test.rs
@@ -110,7 +110,7 @@ fn run_command_for_toolchain() {
         let mut task = Task::new();
         task.command = Some("echo".to_string());
         task.args = Some(vec!["test".to_string()]);
-        task.toolchain = Some(toolchain.to_string());
+        task.toolchain = Some(toolchain.into());
 
         let step = Step {
             name: "test".to_string(),

--- a/src/lib/installer/cargo_plugin_installer.rs
+++ b/src/lib/installer/cargo_plugin_installer.rs
@@ -10,10 +10,11 @@ mod cargo_plugin_installer_test;
 use crate::command;
 use crate::installer::crate_version_check;
 use crate::toolchain::wrap_command;
+use crate::types::ToolchainSpecifier;
 use envmnt;
 use std::process::Command;
 
-fn is_crate_installed(toolchain: &Option<String>, crate_name: &str) -> bool {
+fn is_crate_installed(toolchain: &Option<ToolchainSpecifier>, crate_name: &str) -> bool {
     debug!("Getting list of installed cargo commands.");
 
     let mut command_struct = match toolchain {
@@ -109,7 +110,7 @@ pub(crate) fn get_install_crate_args(
 }
 
 pub(crate) fn install_crate(
-    toolchain: &Option<String>,
+    toolchain: &Option<ToolchainSpecifier>,
     cargo_command: &str,
     crate_name: &str,
     args: &Option<Vec<String>>,

--- a/src/lib/installer/crate_installer.rs
+++ b/src/lib/installer/crate_installer.rs
@@ -11,9 +11,9 @@ use crate::command;
 use crate::installer::crate_version_check;
 use crate::installer::{cargo_plugin_installer, rustup_component_installer};
 use crate::toolchain::wrap_command;
-use crate::types::{CommandSpec, InstallCrateInfo, InstallRustupComponentInfo};
+use crate::types::{CommandSpec, InstallCrateInfo, InstallRustupComponentInfo, ToolchainSpecifier};
 
-fn invoke_rustup_install(toolchain: &Option<String>, info: &InstallCrateInfo) -> bool {
+fn invoke_rustup_install(toolchain: &Option<ToolchainSpecifier>, info: &InstallCrateInfo) -> bool {
     match info.rustup_component_name {
         Some(ref component) => {
             let rustup_component_info = InstallRustupComponentInfo {
@@ -28,7 +28,7 @@ fn invoke_rustup_install(toolchain: &Option<String>, info: &InstallCrateInfo) ->
 }
 
 fn invoke_cargo_install(
-    toolchain: &Option<String>,
+    toolchain: &Option<ToolchainSpecifier>,
     info: &InstallCrateInfo,
     args: &Option<Vec<String>>,
     validate: bool,
@@ -77,7 +77,7 @@ fn is_crate_only_info(info: &InstallCrateInfo) -> bool {
 }
 
 pub(crate) fn install(
-    toolchain: &Option<String>,
+    toolchain: &Option<ToolchainSpecifier>,
     info: &InstallCrateInfo,
     args: &Option<Vec<String>>,
     validate: bool,

--- a/src/lib/installer/mod.rs
+++ b/src/lib/installer/mod.rs
@@ -47,10 +47,7 @@ fn get_cargo_plugin_info_from_command(task_config: &Task) -> Option<(String, Str
 pub(crate) fn install(task_config: &Task, flow_info: &FlowInfo) {
     let validate = !task_config.should_ignore_errors();
 
-    let toolchain = match task_config.toolchain {
-        Some(ref value) => Some(value.to_string()),
-        None => None,
-    };
+    let toolchain = task_config.toolchain.clone();
 
     let mut install_crate = task_config.install_crate.clone();
     if let Some(ref install_crate_value) = install_crate {

--- a/src/lib/installer/rustup_component_installer.rs
+++ b/src/lib/installer/rustup_component_installer.rs
@@ -9,10 +9,14 @@ mod rustup_component_installer_test;
 
 use crate::command;
 use crate::toolchain::wrap_command;
-use crate::types::InstallRustupComponentInfo;
+use crate::types::{InstallRustupComponentInfo, ToolchainSpecifier};
 use std::process::Command;
 
-pub(crate) fn is_installed(toolchain: &Option<String>, binary: &str, test_args: &[String]) -> bool {
+pub(crate) fn is_installed(
+    toolchain: &Option<ToolchainSpecifier>,
+    binary: &str,
+    test_args: &[String],
+) -> bool {
     let mut command_struct = match toolchain {
         Some(ref toolchain_string) => {
             let command_spec = wrap_command(toolchain_string, binary, &None);
@@ -52,7 +56,7 @@ pub(crate) fn is_installed(toolchain: &Option<String>, binary: &str, test_args: 
 }
 
 pub(crate) fn invoke_rustup_install(
-    toolchain: &Option<String>,
+    toolchain: &Option<ToolchainSpecifier>,
     info: &InstallRustupComponentInfo,
 ) -> bool {
     let mut command_spec = Command::new("rustup");
@@ -60,9 +64,9 @@ pub(crate) fn invoke_rustup_install(
     command_spec.arg("add");
 
     match toolchain {
-        Some(ref toolchain_string) => {
+        Some(ref toolchain) => {
             command_spec.arg("--toolchain");
-            command_spec.arg(toolchain_string);
+            command_spec.arg(toolchain.channel());
         }
         None => {}
     };
@@ -100,7 +104,7 @@ pub(crate) fn invoke_rustup_install(
 }
 
 pub(crate) fn install(
-    toolchain: &Option<String>,
+    toolchain: &Option<ToolchainSpecifier>,
     info: &InstallRustupComponentInfo,
     validate: bool,
 ) -> bool {

--- a/src/lib/test/mod.rs
+++ b/src/lib/test/mod.rs
@@ -1,6 +1,6 @@
 use crate::logger;
 use crate::logger::LoggerOptions;
-use crate::types::{Config, ConfigSection, CrateInfo, EnvInfo, FlowInfo};
+use crate::types::{Config, ConfigSection, CrateInfo, EnvInfo, FlowInfo, ToolchainSpecifier};
 use ci_info;
 use ci_info::types::CiInfo;
 use fsio;
@@ -99,7 +99,7 @@ pub(crate) fn is_not_rust_stable() -> bool {
     }
 }
 
-pub(crate) fn get_toolchain() -> String {
+pub(crate) fn get_toolchain() -> ToolchainSpecifier {
     on_test_startup();
 
     let rustinfo = rust_info::get();
@@ -110,7 +110,7 @@ pub(crate) fn get_toolchain() -> String {
         RustChannel::Nightly => "nightly",
     };
 
-    toolchain.to_string()
+    toolchain.into()
 }
 
 pub(crate) fn create_empty_flow_info() -> FlowInfo {

--- a/src/lib/toolchain_test.rs
+++ b/src/lib/toolchain_test.rs
@@ -6,7 +6,7 @@ use envmnt;
 #[should_panic]
 fn wrap_command_invalid_toolchain() {
     if test::is_not_rust_stable() {
-        wrap_command("invalid-chain", "true", &None);
+        wrap_command(&"invalid-chain".into(), "true", &None);
     } else {
         panic!("test");
     }
@@ -14,7 +14,7 @@ fn wrap_command_invalid_toolchain() {
 
 #[test]
 fn wrap_command_none_args() {
-    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL");
+    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL").into();
     let output = wrap_command(&channel, "true", &None);
 
     assert_eq!(output.command, "rustup".to_string());
@@ -22,13 +22,13 @@ fn wrap_command_none_args() {
     let args = output.args.unwrap();
     assert_eq!(args.len(), 3);
     assert_eq!(args[0], "run".to_string());
-    assert_eq!(args[1], channel);
+    assert_eq!(args[1], channel.channel());
     assert_eq!(args[2], "true".to_string());
 }
 
 #[test]
 fn wrap_command_empty_args() {
-    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL");
+    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL").into();
     let output = wrap_command(&channel, "true", &Some(vec![]));
 
     assert_eq!(output.command, "rustup".to_string());
@@ -36,13 +36,13 @@ fn wrap_command_empty_args() {
     let args = output.args.unwrap();
     assert_eq!(args.len(), 3);
     assert_eq!(args[0], "run".to_string());
-    assert_eq!(args[1], channel);
+    assert_eq!(args[1], channel.channel());
     assert_eq!(args[2], "true".to_string());
 }
 
 #[test]
 fn wrap_command_with_args() {
-    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL");
+    let channel = envmnt::get_or_panic("CARGO_MAKE_RUST_CHANNEL").into();
     let output = wrap_command(
         &channel,
         "true",
@@ -54,7 +54,7 @@ fn wrap_command_with_args() {
     let args = output.args.unwrap();
     assert_eq!(args.len(), 5);
     assert_eq!(args[0], "run".to_string());
-    assert_eq!(args[1], channel);
+    assert_eq!(args[1], channel.channel());
     assert_eq!(args[2], "true".to_string());
     assert_eq!(args[3], "echo".to_string());
     assert_eq!(args[4], "test".to_string());

--- a/src/lib/types_test.rs
+++ b/src/lib/types_test.rs
@@ -1532,7 +1532,7 @@ fn task_extend_extended_have_all_fields() {
         script_extension: Some("ext2".to_string()),
         run_task: Some(RunTaskInfo::Name("task2".to_string())),
         dependencies: Some(vec!["A".into()]),
-        toolchain: Some("toolchain".to_string()),
+        toolchain: Some("toolchain".into()),
         linux: Some(PlatformOverrideTask {
             clear: Some(true),
             install_crate: Some(InstallCrate::Value("my crate2".to_string())),
@@ -1576,7 +1576,7 @@ fn task_extend_extended_have_all_fields() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
         windows: Some(PlatformOverrideTask {
             clear: Some(false),
@@ -1621,7 +1621,7 @@ fn task_extend_extended_have_all_fields() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
         mac: Some(PlatformOverrideTask {
             clear: None,
@@ -1666,7 +1666,7 @@ fn task_extend_extended_have_all_fields() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
     };
 
@@ -1744,7 +1744,7 @@ fn task_extend_extended_have_all_fields() {
     };
     assert_eq!(run_task_name, "task2".to_string());
     assert_eq!(base.dependencies.unwrap().len(), 1);
-    assert_eq!(base.toolchain.unwrap(), "toolchain");
+    assert_eq!(base.toolchain.unwrap(), "toolchain".into());
     assert!(base.linux.unwrap().clear.unwrap());
     assert!(!base.windows.unwrap().clear.unwrap());
     assert!(base.mac.unwrap().clear.is_none());
@@ -1807,7 +1807,7 @@ fn task_extend_clear_with_no_data() {
         script_extension: Some("ext2".to_string()),
         run_task: Some(RunTaskInfo::Name("task2".to_string())),
         dependencies: Some(vec!["A".into()]),
-        toolchain: Some("toolchain".to_string()),
+        toolchain: Some("toolchain".into()),
         linux: Some(PlatformOverrideTask {
             clear: Some(true),
             install_crate: Some(InstallCrate::Value("my crate2".to_string())),
@@ -1851,7 +1851,7 @@ fn task_extend_clear_with_no_data() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
         windows: Some(PlatformOverrideTask {
             clear: Some(false),
@@ -1896,7 +1896,7 @@ fn task_extend_clear_with_no_data() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
         mac: Some(PlatformOverrideTask {
             clear: None,
@@ -1941,7 +1941,7 @@ fn task_extend_clear_with_no_data() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
     };
 
@@ -2042,7 +2042,7 @@ fn task_extend_clear_with_all_data() {
         script_extension: Some("ext2".to_string()),
         run_task: Some(RunTaskInfo::Name("task2".to_string())),
         dependencies: Some(vec!["A".into()]),
-        toolchain: Some("toolchain".to_string()),
+        toolchain: Some("toolchain".into()),
         linux: Some(PlatformOverrideTask {
             clear: Some(true),
             install_crate: Some(InstallCrate::Value("my crate2".to_string())),
@@ -2086,7 +2086,7 @@ fn task_extend_clear_with_all_data() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
         windows: Some(PlatformOverrideTask {
             clear: Some(false),
@@ -2131,7 +2131,7 @@ fn task_extend_clear_with_all_data() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
         mac: Some(PlatformOverrideTask {
             clear: None,
@@ -2176,7 +2176,7 @@ fn task_extend_clear_with_all_data() {
             script_extension: Some("ext3".to_string()),
             run_task: Some(RunTaskInfo::Name("task3".to_string())),
             dependencies: Some(vec!["A".into()]),
-            toolchain: Some("toolchain".to_string()),
+            toolchain: Some("toolchain".into()),
         }),
     };
 
@@ -2289,7 +2289,7 @@ fn task_get_normalized_task_undefined() {
         script_extension: Some("ext1".to_string()),
         run_task: Some(RunTaskInfo::Name("task1".to_string())),
         dependencies: Some(vec!["1".into()]),
-        toolchain: Some("toolchain2".to_string()),
+        toolchain: Some("toolchain2".into()),
         description: Some("description".to_string()),
         category: Some("category".to_string()),
         workspace: Some(false),
@@ -2369,7 +2369,7 @@ fn task_get_normalized_task_undefined() {
     };
     assert_eq!(run_task_name, "task1".to_string());
     assert_eq!(normalized_task.dependencies.unwrap().len(), 1);
-    assert_eq!(normalized_task.toolchain.unwrap(), "toolchain2");
+    assert_eq!(normalized_task.toolchain.unwrap(), "toolchain2".into());
 }
 
 #[test]
@@ -2428,7 +2428,7 @@ fn task_get_normalized_task_with_override_no_clear() {
         script_extension: Some("ext1".to_string()),
         run_task: Some(RunTaskInfo::Name("task1".to_string())),
         dependencies: Some(vec!["1".into()]),
-        toolchain: Some("toolchain1".to_string()),
+        toolchain: Some("toolchain1".into()),
         linux: Some(PlatformOverrideTask {
             clear: None,
             install_crate: Some(InstallCrate::Value("linux_crate".to_string())),
@@ -2481,7 +2481,7 @@ fn task_get_normalized_task_with_override_no_clear() {
             script_extension: Some("ext2".to_string()),
             run_task: Some(RunTaskInfo::Name("task2".to_string())),
             dependencies: Some(vec!["1".into(), "2".into()]),
-            toolchain: Some("toolchain2".to_string()),
+            toolchain: Some("toolchain2".into()),
         }),
         windows: None,
         mac: None,
@@ -2563,7 +2563,7 @@ fn task_get_normalized_task_with_override_no_clear() {
     };
     assert_eq!(run_task_name, "task2".to_string());
     assert_eq!(normalized_task.dependencies.unwrap().len(), 2);
-    assert_eq!(normalized_task.toolchain.unwrap(), "toolchain2");
+    assert_eq!(normalized_task.toolchain.unwrap(), "toolchain2".into());
 
     let condition = normalized_task.condition.unwrap();
     assert_eq!(condition.platforms.unwrap().len(), 2);
@@ -2626,7 +2626,7 @@ fn task_get_normalized_task_with_override_clear_false() {
         script_extension: Some("ext1".to_string()),
         run_task: Some(RunTaskInfo::Name("task1".to_string())),
         dependencies: Some(vec!["1".into()]),
-        toolchain: Some("toolchain1".to_string()),
+        toolchain: Some("toolchain1".into()),
         linux: Some(PlatformOverrideTask {
             clear: Some(false),
             install_crate: Some(InstallCrate::Value("linux_crate".to_string())),
@@ -2683,7 +2683,7 @@ fn task_get_normalized_task_with_override_clear_false() {
             script_extension: Some("ext2".to_string()),
             run_task: Some(RunTaskInfo::Name("task2".to_string())),
             dependencies: Some(vec!["1".into(), "2".into()]),
-            toolchain: Some("toolchain2".to_string()),
+            toolchain: Some("toolchain2".into()),
         }),
         windows: None,
         mac: None,
@@ -2765,7 +2765,7 @@ fn task_get_normalized_task_with_override_clear_false() {
     };
     assert_eq!(run_task_name, "task2".to_string());
     assert_eq!(normalized_task.dependencies.unwrap().len(), 2);
-    assert_eq!(normalized_task.toolchain.unwrap(), "toolchain2");
+    assert_eq!(normalized_task.toolchain.unwrap(), "toolchain2".into());
 
     let condition = normalized_task.condition.unwrap();
     assert_eq!(condition.platforms.unwrap().len(), 1);
@@ -2822,7 +2822,7 @@ fn task_get_normalized_task_with_override_clear_false_partial_override() {
         script_extension: Some("ext1".to_string()),
         run_task: Some(RunTaskInfo::Name("task1".to_string())),
         dependencies: Some(vec!["1".into()]),
-        toolchain: Some("toolchain1".to_string()),
+        toolchain: Some("toolchain1".into()),
         description: None,
         category: None,
         workspace: None,
@@ -2929,7 +2929,7 @@ fn task_get_normalized_task_with_override_clear_false_partial_override() {
     };
     assert_eq!(run_task_name, "task1".to_string());
     assert_eq!(normalized_task.dependencies.unwrap().len(), 1);
-    assert_eq!(normalized_task.toolchain.unwrap(), "toolchain1");
+    assert_eq!(normalized_task.toolchain.unwrap(), "toolchain1".into());
 }
 
 #[test]
@@ -2982,7 +2982,7 @@ fn task_get_normalized_task_with_override_clear_true() {
         script_extension: Some("ext1".to_string()),
         run_task: Some(RunTaskInfo::Name("task1".to_string())),
         dependencies: Some(vec!["1".into()]),
-        toolchain: Some("toolchain1".to_string()),
+        toolchain: Some("toolchain1".into()),
         description: Some("description".to_string()),
         category: Some("category".to_string()),
         workspace: Some(false),


### PR DESCRIPTION
As described in #594, this let's us specify a minimal version expected to be present for toolchains with descriptive names like `stable` so that users that didn't (or couldn't) yet update their rust version can error instead of running into compile errors later due to missing features (like `edition_2021`).

Closes #594 

- [x] Implement MVI
- [ ] Add test cases
- [ ] Add documentation

