### PR TITLE
Examples for showing a list of tasks via duckscript / rust-script colored text

### DIFF
--- a/examples/usage-duckscript/Makefile.toml
+++ b/examples/usage-duckscript/Makefile.toml
@@ -1,0 +1,10 @@
+# This is the top level cargo make file
+
+extend = [
+
+  # Include the usage toml file
+  # This is an example of using colored text via duckscript
+  # to show a list of available commands
+  { path = "./usage.toml" },
+
+]

--- a/examples/usage-duckscript/usage.toml
+++ b/examples/usage-duckscript/usage.toml
@@ -1,0 +1,61 @@
+# This is an example of displaying a usage list for available commands.
+# This uses cargo make's inbuild duckscript with colored text as an example.
+
+# This is an example of overriding the default output if "caro make" is run with no parameters
+[tasks.default]
+alias = "list"
+
+# Alias the "usage" task to "list"
+[tasks.usage]
+alias = "list"
+
+# List the available tasks
+[tasks.list]
+script_runner = "@duckscript"
+script = '''
+
+# In order to make handling colors easy
+# Use functions to show the output
+
+fn title
+    println --style bold --color yellow ${1}
+    println "==============="
+end
+
+fn taskitem
+    print --style bold ${1}
+    print --color cyan ${2}
+end
+
+fn footer
+    print --color yellow ${1}
+end
+
+print \n
+title    "Build Tasks"
+taskitem "cargo make [-p prod] build"         "\t\t Build the source\n"
+taskitem "cargo make [-p prod] elf2image"     "\t\t Convert the built elf file into a flashable .bin file\n"
+taskitem "cargo make [-p prod] imageinfo"     "\t\t Show information about the flash bin image\n"
+taskitem "cargo make [-p prod] flash"         "\t\t Build and Upload the flash image to the board\n"
+taskitem "cargo make [-p prod] verifyflash"   "\t Verify the uploaded flash image\n"
+
+print \n
+title    "Util Tasks"
+taskitem "cargo make list"         "\t\t\t\t List the available tasks\n"
+taskitem "cargo make fmt"          "\t\t\t\t Reformat the source\n"
+taskitem "cargo make clean"        "\t\t\t Clean the target directory\n"
+
+print \n
+title    "Flash Util Tasks"
+taskitem "cargo make flashid"      "\t\t\t Display flash information about the attached board\n"
+taskitem "cargo make chipid"       "\t\t\t Display chip id information about the attached board\n"
+taskitem "cargo make flashstatus"  "\t\t\t Display flash status information about the attached board\n"
+taskitem "cargo make eraseflash"   "\t\t\t Erase the flash on the attached board\n"
+taskitem "cargo make readmac"      "\t\t\t Read the network mac address of the board\n"
+taskitem "cargo make run"          "\t\t\t\t Run the app\n"
+
+print \n
+footer "The default is to build a development / debug image\n"
+footer "use \"-p prod\" to build a smaller release image with no debugging info\n"
+print \n
+'''

--- a/examples/usage-rustscript/Makefile.toml
+++ b/examples/usage-rustscript/Makefile.toml
@@ -1,0 +1,10 @@
+# This is the top level cargo make file
+
+extend = [
+
+  # Include the usage toml file
+  # This is an example of using colored text via rust-script
+  # to show a list of available commands
+  { path = "./usage.toml" },
+
+]

--- a/examples/usage-rustscript/usage.ers
+++ b/examples/usage-rustscript/usage.ers
@@ -1,0 +1,59 @@
+#!/usr/bin/env rust-script
+// cargo-deps: colored
+
+use colored::*;
+
+fn main() {
+    let mut s = String::new();
+
+    append(&mut s, "\n");
+    append(&mut s, "Build Tasks\n".bold().yellow());
+    append(&mut s, "===============\n");
+    append(&mut s, "cargo make [-p prod] build".bold());
+    append(&mut s, "\t\t Build the source\n".cyan());
+    append(&mut s, "cargo make [-p prod] elf2image".bold());
+    append(&mut s, "\t\t Convert the built elf file into a flashable .bin file\n".cyan());
+    append(&mut s, "cargo make [-p prod] imageinfo".bold());
+    append(&mut s, "\t\t Show information about the flash bin image\n".cyan());
+    append(&mut s, "cargo make [-p prod] flash".bold());
+    append(&mut s, "\t\t Build and Upload the flash image to the board\n".cyan());
+    append(&mut s, "cargo make [-p prod] verifyflash".bold());
+    append(&mut s, "\t Verify the uploaded flash image\n".cyan());
+
+    append(&mut s, "\n");
+    append(&mut s, "Util Tasks\n".bold().yellow());
+    append(&mut s, "===============\n");
+    append(&mut s, "cargo make list".bold());
+    append(&mut s, "\t\t\t\t List the available tasks\n".cyan());
+    append(&mut s, "cargo make fmt".bold());
+    append(&mut s, "\t\t\t\t Reformat the source\n".cyan());
+    append(&mut s, "cargo make clean".bold());
+    append(&mut s, "\t\t\t Clean the target directory\n".cyan());
+
+    append(&mut s, "\n");
+    append(&mut s, "Flash Util Tasks\n".bold().yellow());
+    append(&mut s, "===============\n");
+    append(&mut s, "cargo make flashid".bold());
+    append(&mut s, "\t\t\t Display flash information about the attached board\n".cyan());
+    append(&mut s, "cargo make chipid".bold());
+    append(&mut s, "\t\t\t Display chip id information about the attached board\n".cyan());
+    append(&mut s, "cargo make flashstatus".bold());
+    append(&mut s, "\t\t\t Display flash status information about the attached board\n".cyan());
+    append(&mut s, "cargo make eraseflash".bold());
+    append(&mut s, "\t\t\t Erase the flash on the attached board\n".cyan());
+    append(&mut s, "cargo make readmac".bold());
+    append(&mut s, "\t\t\t Read the network mac address of the board\n".cyan());
+    append(&mut s, "cargo make run".bold());
+    append(&mut s, "\t\t\t\t Run the app code in flash\n".cyan());
+
+    append(&mut s, "\n");
+    append(&mut s, "The default is to build a development / debug image\n".yellow());
+    append(&mut s, "use \"-p prod\" to build a smaller release image with no debugging info\n".yellow());
+
+    println!("{}", s);
+}
+
+// Append String or ColoredString to source string
+fn append<I>(source: &mut String, val: I) where I: ToString {
+    let _ = &source.push_str(&val.to_string());
+}

--- a/examples/usage-rustscript/usage.toml
+++ b/examples/usage-rustscript/usage.toml
@@ -1,0 +1,31 @@
+# This is an example of displaying a usage list for available commands.
+# This uses cargo make's rust-script support with colored text as an example.
+
+# Note rust script has some advantages / disadvantages vs duckscript
+# For general colored text usage duckscript is currently the better option.
+
+# Advantages include:
+# 1. The ability to run scripts with rust libraries such as - https://github.com/fdehau/tui-rs
+
+# Disadvantages Include:
+# 1. The rust script has to be compiled which is slower to run
+# 2. Additional disk space is taken up in the rust-script cache
+# 2. Currently rust-script picks up cargo config information / target overrides such as .cargo/config.toml
+#    If the script is located within a project directory.
+#    If the project targets a different arch than the host or has special compile options this can also cause issues
+#    https://github.com/fornwall/rust-script/issues/31
+
+# This is an example of overriding the default output if "caro make" is run with no parameters
+[tasks.default]
+alias = "list"
+
+# Alias the "usage" task to "list"
+[tasks.usage]
+alias = "list"
+
+# Call usage.ers
+[tasks.list]
+command = "rust-script"
+cwd = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}"
+args = ["./usage.ers"]
+category = "Common"


### PR DESCRIPTION
Hi,
I've attached a couple of examples of using colored text ether via duckscript (which is the better quicker option)
or via rust-script to show a list of tasks.

It's mostly a copy / paste of an embedded project I'm working on so you may want to reformat it perhaps.
I've found using duckscript functions to define the color formatting the better way of doing things.

The only thing I couldn't figure out how to suppress were the info messages before / after the output.