### PR TITLE
Add Cargo features `edition2021`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2021"]
+
 [package]
 name = "cargo-make"
 version = "0.35.8"


### PR DESCRIPTION
This is required when setting `package.edition` to `2021`.