### PR TITLE
Double Ctrl+C

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ cargo_metadata = "^0.14.0"
 ci_info = "^0.14.3"
 clap = "^3.1"
 colored = "^2"
+ctrlc = "^3.2.2"
 dirs-next = "^2"
 duckscript = "^0.7.1"
 duckscriptsdk = { version = "^0.8.10", default-features = false }

--- a/src/lib/command.rs
+++ b/src/lib/command.rs
@@ -169,8 +169,8 @@ pub(crate) fn run_command_get_output(
     };
 
     command.stdin(Stdio::inherit());
-    if !capture_output {
-        command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    if capture_output {
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
     }
     info!("Execute Command: {:#?}", &command);
 

--- a/src/lib/descriptor/mod.rs
+++ b/src/lib/descriptor/mod.rs
@@ -675,5 +675,13 @@ pub(crate) fn load(
 
     load_cargo_aliases(&mut config);
 
+    if let Some(unstable_features) = &config.config.unstable_features {
+        for feature in unstable_features {
+            config
+                .env
+                .insert(feature.to_env_name(), EnvValue::Boolean(true));
+        }
+    }
+
     Ok(config)
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -110,7 +110,6 @@
     unstable_features,
     unstable_name_collisions,
     unsupported_calling_conventions,
-    unsupported_naked_functions,
     unused_allocation,
     unused_assignments,
     unused_assignments,

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -11,7 +11,7 @@ use crate::legacy;
 use crate::plugin::types::Plugins;
 use ci_info::types::CiInfo;
 use git_info::types::GitInfo;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use regex::Regex;
 use rust_info::types::RustInfo;
 use std::collections::HashMap;
@@ -1991,6 +1991,27 @@ impl ModifyConfig {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+/// Unstable cargo-make feature
+pub enum UnstableFeature {
+    /// Gracefully shutdown and then kill the running command on Ctrl+C signal
+    CtrlCHandling,
+}
+
+impl UnstableFeature {
+    /// Creates the env. variable name associated to the feature
+    pub fn to_env_name(&self) -> String {
+        let feature = serde_json::to_string(&self).unwrap();
+        format!("CARGO_MAKE_UNSTABLE_FEATURE_{feature}")
+    }
+
+    /// Is the corresponding env. variable set?
+    pub fn is_env_set(&self) -> bool {
+        envmnt::is(self.to_env_name())
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 /// Holds the configuration found in the makefile toml config section.
 pub struct ConfigSection {
@@ -2034,6 +2055,8 @@ pub struct ConfigSection {
     pub windows_load_script: Option<ScriptValue>,
     /// acts like load_script if runtime OS is Mac (takes precedence over load_script)
     pub mac_load_script: Option<ScriptValue>,
+    /// Enables unstable cargo-make features
+    pub unstable_features: Option<IndexSet<UnstableFeature>>,
 }
 
 impl ConfigSection {
@@ -2172,6 +2195,14 @@ impl ConfigSection {
                 self.mac_load_script.clone(),
                 extended.mac_load_script.clone(),
             );
+        }
+
+        if let Some(extended_unstable_features) = extended.unstable_features.clone() {
+            if let Some(unstable_features) = &mut self.unstable_features {
+                unstable_features.extend(extended_unstable_features);
+            } else {
+                self.unstable_features = Some(extended_unstable_features);
+            }
         }
     }
 


### PR DESCRIPTION
Related issue: #374 

Resolves the problem when the `cargo-make` binary exits too early (because of receiving Ctrl+C signal) but the task command is still running (either it's shutting down or becoming a zombie process).

The first Ctrl+C press writes `Shutting down...` to the terminal and waits for the command to shut down gracefully. The second press kills the command and waits for its exit status.

Tested manually with a new "playground repo" [makers_tester](https://github.com/MartinKavik/makers_tester) and with [MoonZoon](https://github.com/MoonZoon/MoonZoon) examples. `cargo-make` unit tests pass (run in Git hooks). Tested on Windows.

I'm not sure if the `loop` is the most efficient implementation but I didn't want to introduce some async runtimes or complex streaming/channels in the code.

P.S. `cargo-make` writes `[cargo-make] INFO - Build Done in 22.51 seconds.` when the task is finished. The `Build Done` text doesn't make too much sense when the task is a running server or something like that. Just fyi.