### PR TITLE
Allow building with native-tls instead of rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ clap = "^3.1"
 colored = "^2"
 ctrlc = "^3.2.2"
 dirs-next = "^2"
-duckscript = "^0.7.2"
-duckscriptsdk = { version = "^0.8.12", default-features = false }
+duckscript = "^0.7.3"
+duckscriptsdk = { version = "^0.8.13", default-features = false }
 envmnt = "^0.10.0"
 fern = "^0.6"
 fsio = { version = "^0.3.1", features = ["temp-path"] }
@@ -76,8 +76,10 @@ toml = "^0.5"
 ansi_term = "^0.12.1"
 
 [features]
-tls = ["duckscriptsdk/tls"]
-default = ["tls"]
+tls-rustls = ["duckscriptsdk/tls-rustls"]
+tls-native = ["duckscriptsdk/tls-native"]
+tls = ["tls-rustls"]  # alias for backward compatibility
+default = ["tls-rustls"]
 
 [badges.codecov]
 branch = "master"


### PR DESCRIPTION
Bundling (static linking) TLS library is a very bad idea from a security perspective and linux distributions try to avoid it.

See-Also: https://github.com/sagiegurari/duckscript/pull/258