### PR TITLE
Extent format-toml with optional arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,18 +1121,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/lib/descriptor/makefiles/toml.toml
+++ b/src/lib/descriptor/makefiles/toml.toml
@@ -10,7 +10,7 @@ install_crate = { crate_name = "taplo-cli", binary = "taplo", test_arg = [
   "--help",
 ] }
 command = "taplo"
-args = ["format", "${CARGO_MAKE_FORMAT_TOML_FILES}"]
+args = ["format", "${CARGO_MAKE_FORMAT_TOML_FILES}", "@@split(CARGO_MAKE_FORMAT_TOML_ARGS, )",]
 
 [tasks.post-format-toml]
 category = "Development"


### PR DESCRIPTION
With this patch, it is possible to extend format-toml target with arbitrary space-separated arguments.

One of the use-cases for this may be running a read-only toml check, which could fail CI in case a TOML file is not formatted correctly:

```toml
[tasks.check-toml]
env = { CARGO_MAKE_FORMAT_TOML_ARGS = "--check" }
run_task = { name = "format-toml" }
```