### PR TITLE
Enhancement: Support environment substitution in files_modified condition

### DIFF
--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -1679,7 +1679,7 @@ The following condition types are available:
 * **rust_version** - Optional definition of min, max, and/or specific rust version
 * **files_exist** - List of absolute path files to check they exist. Environment substitution is supported so you can define relative paths such as **`${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml`**
 * **files_not_exist** - List of absolute path files to check they do not exist. Environment substitution is supported so you can define relative paths such as **`${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml`**
-* **files_modified** - Lists input and output globs. If any input file is newer than all output files, the condition is met.
+* **files_modified** - Lists input and output globs. If any input file is newer than all output files, the condition is met. Environment substitution is supported so you can define relative paths such as **`${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml`**
 
 Few examples:
 
@@ -1695,7 +1695,7 @@ condition = {
     rust_version = { min = "1.20.0", max = "1.30.0" },
     files_exist = ["${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml"],
     files_not_exist = ["${CARGO_MAKE_WORKING_DIRECTORY}/Cargo2.toml"],
-    files_modified = { input = ["./Cargo.toml", "./src/**/*.rs"], output = ["./target/**/myapp*"] }
+    files_modified = { input = ["${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml", "./src/**/*.rs"], output = ["./target/**/myapp*"] }
 }
 ```
 
@@ -1779,7 +1779,7 @@ In the below example, if the target binaries are newer then the Cargo.toml or an
 
 ```toml
 [tasks.compile-if-modified]
-condition = { files_modified = { input = ["./Cargo.toml", "./src/**/*.rs"], output = ["./target/**/myapp*"] } }
+condition = { files_modified = { input = ["${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml", "./src/**/*.rs"], output = ["./target/**/myapp*"] } }
 command = "cargo"
 args = ["build"]
 ```

--- a/src/lib/condition.rs
+++ b/src/lib/condition.rs
@@ -279,7 +279,7 @@ fn validate_files_not_exist(condition: &TaskCondition) -> bool {
 }
 
 fn validate_files_modified(condition: &TaskCondition) -> bool {
-    match condition.files_modified.clone() {
+    match &condition.files_modified {
         Some(files_modified) => {
             if files_modified.input.len() == 0 {
                 return true;
@@ -287,7 +287,8 @@ fn validate_files_modified(condition: &TaskCondition) -> bool {
 
             let mut latest_binary = 0;
             for glob_pattern in &files_modified.output {
-                match glob(glob_pattern) {
+                let glob_pattern = environment::expand_value(glob_pattern);
+                match glob(&glob_pattern) {
                     Ok(paths) => {
                         for entry in paths {
                             match entry {
@@ -331,7 +332,8 @@ fn validate_files_modified(condition: &TaskCondition) -> bool {
                 true
             } else {
                 for glob_pattern in &files_modified.input {
-                    match glob(glob_pattern) {
+                    let glob_pattern = environment::expand_value(glob_pattern);
+                    match glob(&glob_pattern) {
                         Ok(paths) => {
                             let mut paths_found = false;
                             for entry in paths {

--- a/src/lib/condition_test.rs
+++ b/src/lib/condition_test.rs
@@ -1312,7 +1312,7 @@ fn validate_files_modified_only_input() {
         files_exist: None,
         files_not_exist: None,
         files_modified: Some(FilesFilesModifiedCondition {
-            input: vec!["./Cargo.toml".to_string()],
+            input: vec!["${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml".to_string()],
             output: vec![],
         }),
     };
@@ -1340,7 +1340,7 @@ fn validate_files_modified_only_output() {
         files_not_exist: None,
         files_modified: Some(FilesFilesModifiedCondition {
             input: vec![],
-            output: vec!["./Cargo.toml".to_string()],
+            output: vec!["${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml".to_string()],
         }),
     };
 
@@ -1366,8 +1366,8 @@ fn validate_files_modified_same_timestamp() {
         files_exist: None,
         files_not_exist: None,
         files_modified: Some(FilesFilesModifiedCondition {
-            input: vec!["./Cargo.toml".to_string()],
-            output: vec!["./Cargo.toml".to_string()],
+            input: vec!["${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml".to_string()],
+            output: vec!["${CARGO_MAKE_WORKING_DIRECTORY}/Cargo.toml".to_string()],
         }),
     };
 
@@ -1439,6 +1439,72 @@ fn validate_files_modified_input_newer() {
             files_modified: Some(FilesFilesModifiedCondition {
                 input: vec![target_glob],
                 output: vec![src_glob],
+            }),
+        };
+
+        let enabled = validate_files_modified(&condition);
+
+        assert!(enabled);
+    }
+}
+
+#[test]
+fn validate_files_modified_output_newer_env() {
+    if should_test_unstable() {
+        let directory =
+            setup_test_dir("condition/files_modified/validate_files_modified_output_newer_env");
+        envmnt::set("DIR", directory);
+
+        let condition = TaskCondition {
+            fail_message: None,
+            profiles: None,
+            platforms: None,
+            channels: None,
+            env_set: None,
+            env_not_set: None,
+            env_true: None,
+            env_false: None,
+            env: None,
+            env_contains: None,
+            rust_version: None,
+            files_exist: None,
+            files_not_exist: None,
+            files_modified: Some(FilesFilesModifiedCondition {
+                input: vec!["${DIR}/src/**/*".to_owned()],
+                output: vec!["${DIR}/target/**/*".to_owned()],
+            }),
+        };
+
+        let enabled = validate_files_modified(&condition);
+
+        assert!(!enabled);
+    }
+}
+
+#[test]
+fn validate_files_modified_input_newer_env() {
+    if should_test_unstable() {
+        let directory =
+            setup_test_dir("condition/files_modified/validate_files_modified_input_newer_env");
+        envmnt::set("DIR", directory);
+
+        let condition = TaskCondition {
+            fail_message: None,
+            profiles: None,
+            platforms: None,
+            channels: None,
+            env_set: None,
+            env_not_set: None,
+            env_true: None,
+            env_false: None,
+            env: None,
+            env_contains: None,
+            rust_version: None,
+            files_exist: None,
+            files_not_exist: None,
+            files_modified: Some(FilesFilesModifiedCondition {
+                input: vec!["${DIR}/target/**/*".to_owned()],
+                output: vec!["${DIR}/src/**/*".to_owned()],
             }),
         };
 


### PR DESCRIPTION
Environment substitution is supported in `files_exist` and `files_not_exist`. It took me a while to figure it was not supported in `files_modified` so I added it. Let me know if anything is missing or need modification.