### PR TITLE
Fix line endings (#801)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-* text eol=lf
 *.ico binary
 *.woff binary


### PR DESCRIPTION
When adding a vendor to git, the line endings is forced to change. What contributes to the breakage of the building an RPM pacagefor Linux.