### PR TITLE
Add `aarch64-apple-darwin` binary release target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
 env:
   CLICOLOR_FORCE: 1
 jobs:
@@ -19,6 +20,8 @@ jobs:
             binary_target: x86_64-pc-windows-msvc
           - os: macos-latest
             binary_target: x86_64-apple-darwin
+          - os: macos-latest
+            binary_target: aarch64-apple-darwin
     steps:
     - name: Install musl tools
       if: matrix.os == 'ubuntu-latest'
@@ -28,14 +31,7 @@ jobs:
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
-        profile: minimal
-        override: true
-    - name: Install rust windows msvc target
-      if: matrix.os == 'windows-latest'
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable-x86_64-pc-windows-msvc
+        toolchain: stable-${{ matrix.binary_target }}
         profile: minimal
         override: true
     - name: Build Binary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     tags:
       - '*'
-  workflow_dispatch:
 env:
   CLICOLOR_FORCE: 1
 jobs:
@@ -28,12 +27,11 @@ jobs:
       run: sudo apt-get install musl-tools
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Install rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable-${{ matrix.binary_target }}
-        profile: minimal
-        override: true
+    - name: Update rust
+      run: |
+        rustup override set stable
+        rustup update stable
+        rustup target add ${{ matrix.binary_target }}
     - name: Build Binary
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ env:
   CLICOLOR_FORCE: 1
 jobs:
   build:
-    name: Publish for ${{ matrix.os }}
+    name: Publish for ${{ matrix.binary_target }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
We could potentially put the `rustup target add` in `tasks.setup-release-build-env`. This command already exists in `tasks.setup-musl` so there is a bit of precident for it, but I didn't want to make that choice since it could mess up consumers who are using the `CARGO_MAKE_RELEASE_FLOW_TARGET` env var.

I didn't actually know the `zip-release-ci-flow` built in task existed, maybe I'll switch to that in Knope 😄

Tested by making [this test release in my fork](https://github.com/dbanty/cargo-make/releases/tag/test-aarch64). The relevant new artifact runs on my M1 MacBook.

Closes #766