### PR TITLE
Add link to the documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### v0.36.7
+
+* Documentation: Add documentation link on README for watch attribute #829
+
 ### v0.36.6 (2023-03-01)
 
 * Enhancement: Support environment expansion for files_modified condition #802 (thanks @stormshield-guillaumed)
@@ -977,3 +981,4 @@
 ### v0.1.0 (2017-06-23)
 
 * Initial release.
+

--- a/README.md
+++ b/README.md
@@ -2768,6 +2768,8 @@ args = [ "Triggered by watch" ]
 watch = { postpone = true, no_git_ignore = true, ignore_pattern = "examples/files/*", watch = ["./docs/"] }
 ```
 
+See [the documentation](https://sagiegurari.github.io/cargo-make/api/cli/types/struct.WatchOptions.html) for a description of all the options available.
+
 <a name="usage-watch-running-multiple-blocking-watches"></a>
 #### Running Multiple Blocking Watches
 
@@ -4139,3 +4141,4 @@ See [Changelog](https://github.com/sagiegurari/cargo-make/blob/master/CHANGELOG.
 <a name="license"></a>
 ## License
 Developed by Sagie Gur-Ari and licensed under the Apache 2 open source license.
+

--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -2634,6 +2634,8 @@ args = [ "Triggered by watch" ]
 watch = { postpone = true, no_git_ignore = true, ignore_pattern = "examples/files/*", watch = ["./docs/"] }
 ```
 
+See [the documentation](https://sagiegurari.github.io/cargo-make/api/cli/types/struct.WatchOptions.html) for a description of all the options available.
+
 <a name="usage-watch-running-multiple-blocking-watches"></a>
 #### Running Multiple Blocking Watches
 


### PR DESCRIPTION
Adds a link to the documentation in the README to indicate where the full information is available. 

Instead of explaining the current features and then having to keep both the readme and documentation up to date, I suggest adding the relevant link to the documentation.

Closes #824 