### PR TITLE
crateinfo: do not sort workspace members

### DIFF
--- a/src/lib/environment/crateinfo.rs
+++ b/src/lib/environment/crateinfo.rs
@@ -197,7 +197,6 @@ fn add_members(crate_info: &mut CrateInfo, new_members: Vec<String>) {
 fn dedup_members(crate_info: &mut CrateInfo) {
     if let Some(ref mut workspace) = crate_info.workspace {
         if let Some(ref mut members) = workspace.members {
-            members.sort();
             members.dedup();
         }
     }

--- a/src/lib/environment/crateinfo_test.rs
+++ b/src/lib/environment/crateinfo_test.rs
@@ -50,6 +50,24 @@ fn add_members_workspace_new_members_with_data() {
 }
 
 #[test]
+fn add_members_workspace_non_alpha_ordered() {
+    let mut crate_info = CrateInfo::new();
+
+    crate_info.workspace = Some(Workspace::new());
+    add_members(
+        &mut crate_info,
+        vec!["test2".to_string(), "test1".to_string()],
+    );
+
+    load_workspace_members(&mut crate_info);
+
+    let members = crate_info.workspace.unwrap().members.unwrap();
+    assert_eq!(members.len(), 2);
+    assert_eq!(members[0], "test2".to_owned());
+    assert_eq!(members[1], "test1".to_owned());
+}
+
+#[test]
 fn add_members_workspace_empty_members_with_data() {
     let mut crate_info = CrateInfo::new();
     let mut workspace = Workspace::new();


### PR DESCRIPTION
Official doc states following

> The order of the members is defined by the member attribute in the workspace Cargo.toml.

, but it was broken in commit fe5ca3aba1050d0bce39663e0bd270d2a7d83049.

Remove sorting and add new test-case to catch such problems in future

Closes  #833

Signed-off-by: Pavel Skripkin <paskripkin@gmail.com>