### PR TITLE
Fix of output format autocomplete

### DIFF
--- a/src/lib/cli_commands/list_steps.rs
+++ b/src/lib/cli_commands/list_steps.rs
@@ -163,16 +163,20 @@ pub(crate) fn create_list(
             }
 
             let aliases = if let Some(aliases) = aliases.remove(key) {
-                format!(
-                    " [aliases: {}]",
-                    aliases.into_iter().collect::<Vec<String>>().join(", ")
-                )
+                if just_task_name {
+                    aliases.into_iter().collect::<Vec<String>>().join(" ")
+                } else {
+                    format!(
+                        " [aliases: {}]",
+                        aliases.into_iter().collect::<Vec<String>>().join(", ")
+                    )
+                }
             } else {
                 "".to_string()
             };
 
             if just_task_name {
-                buffer.push_str(&format!("{}{}", &key, aliases));
+                buffer.push_str(&format!("{} {} ", &key, aliases));
             } else {
                 buffer.push_str(&format!(
                     "{}{} - {}{}\n",


### PR DESCRIPTION
If we type a command like the one below, we will get output with no whitespace.
This is causing us to get a false completion when we try to autocomplete according to `extra/shell/makers-completion.bash`.

```
$ makers --loglevel error --list-all-steps --output-format autocomplete
buildbuild-flowbuild-releaseend-build-flowinit-build-flowpost-buildpre-buildworkspace-build-flowauditbench-ci-flowci-coverage-flowci-flowclippy-ci-flowexamples-ci-flowoutdatedoutdated-ci-flowoutdated-flowpost-auditpost-ci-flowpost-outdatedpost-unused-dependenciespost-verify-projectpost-workspace-ci-flowpre-auditpre-ci-flowpre-outdatedpre-unused-dependenciespre-verify-projectpre-workspace-ci-flowunused-dependenciesunused-dependencies-flowverify-projectworkspace-ci-flowworkspace-members-cizip-release-ci-flowcleandelete-lockpost-cleanpre-cleanbintray-uploadbuild-verboseconditioned-check-formatconditioned-clippytest-verbosedev-test-flow [aliases: default]formatformat-flowformat-tomlformat-toml-conditioned-flowformat-toml-flowinstall-rustfmtpost-formatpost-format-tomlpre-formatpre-format-tomlupgrade-dependencieswatch-flowclean-apidocscopy-apidocsdocsdocs-flowmarkdown-include-filespost-docspost-workspace-docspre-docspre-workspace-docsreadme-include-filesreadme-set-crate-versionworkspace-docsworkspace-docs-flowgit-addgit-commitgit-commit-messagegit-delete-merged-branchesgit-pullgit-pushgit-statuspost-git-addpost-git-commitpost-git-pushpost-git-statuspre-git-addpre-git-commitpre-git-pushpre-git-statusendinitbuild-release-for-binary-uploadbuild-publish-flowgithub-publishgithub-publish-curlgithub-publish-custom-namegithub-publish-hubgithub-publish-hublishpackagepost-packagepost-publishpre-packagepre-publishpre-publish-clean-flowpre-publish-conditioned-clean-flowpre-publish-delete-lockpublishpublish-flowupload-artifactsworkspace-publish-flowzip-release-binary-for-targetbenchbench-compilebench-conditioned-compilebench-conditioned-flowbench-flowcheckcheck-examplescheck-flowcheck-formatcheck-format-ci-flowcheck-format-flowcheck-testsclippyclippy-allow-failclippy-flowclippy-routercodecovcodecov-flowcoveragecoverage-flowcoverage-kcovcoverage-tarpaulinexamples-compileexamples-conditioned-compileinstall-clippyinstall-clippy-anyinstall-clippy-rustuppost-benchpost-checkpost-check-formatpost-clippypost-coveragepost-testpre-benchpre-checkpre-check-formatpre-clippypre-coveragepre-testtesttest-customtest-flow [aliases: dev-watch-flow]test-multi-phases-flowtest-single-threadedtest-thread-safetest-with-argsworkspace-coverageworkspace-coverage-packworkspace-members-coveragebuild-file-incrementbuild-file-increment-flowdo-on-membersemptygit-diff-files [aliases: diff-files]github-hub-findinstall-rlsinstall-rust-srcinstall-zippost-build-file-incrementpost-print-envpre-build-file-incrementpre-print-envprint-cargo-envprint-cargo-make-envprint-ci-envprint-crate-envprint-duckscript-envprint-env-flowprint-git-envprint-project-envprint-rust-envsetup-sudo-envwaitinstall-wasm-packwasm-pack-basewasm-pack-packwasm-pack-publishwasm-pack-test⏎
```

This PR corrects this problem by:

- Properly Join Whitespace
- When autocomplete is specified, do not enclose the string in `[alias: ... ]` when autocomplete is specified.
