### PR TITLE
Fix Readme about Binary Release Target

### DIFF
--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -35,10 +35,11 @@ cargo install --no-default-features --force cargo-make
 Binary releases are available in the [github releases page](https://github.com/sagiegurari/cargo-make/releases).<br>
 The following binaries are available for each release:
 
+* x86_64-unknown-linux-gnu
 * x86_64-unknown-linux-musl
 * x86_64-apple-darwin
 * x86_64-pc-windows-msvc
-* arm-unknown-linux-gnueabihf
+* aarch64-apple-darwin
 
 <a name="usage"></a>
 ## Usage


### PR DESCRIPTION
From #812 #853, binary release targets(`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`) have been added. And according to #738, the `arm-unknown-linux-gnueabihf` binary is not provided on GitHub Release.
But binary releases section on Readme is outdated. So I fixed the binary release target.

