### PR TITLE
Revert "Fix: If rust-script is used and requires installation, install old 0.7.0 version due to rust-script bug"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,7 @@
 * Fix: Panic during crate installation in case args are empty #615
 * Enhancement: New list-category-steps command #603 (thanks @grbd)
 * Enhancement: New tls feature so tls can be disabled (by default enabled) #614
+* Fix: If rust-script is used and requires installation, install old 0.7.0 version due to rust-script bug
 
 ### v0.35.6 (2021-11-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,6 @@
 * Fix: Panic during crate installation in case args are empty #615
 * Enhancement: New list-category-steps command #603 (thanks @grbd)
 * Enhancement: New tls feature so tls can be disabled (by default enabled) #614
-* Fix: If rust-script is used and requires installation, install old 0.7.0 version due to rust-script bug
 
 ### v0.35.6 (2021-11-01)
 

--- a/src/lib/scriptengine/rsscript.rs
+++ b/src/lib/scriptengine/rsscript.rs
@@ -47,10 +47,7 @@ fn install_crate(provider: &ScriptRunner) {
                 force: None,
             };
 
-            // due to fornwall/rust-script/issues/42
-            let rust_script_install_args = vec!["--version".to_string(), "0.7.0".to_string()];
-
-            crate_installer::install(&None, &info, &Some(rust_script_install_args), false);
+            crate_installer::install(&None, &info, &None, false);
         }
         ScriptRunner::CargoScript => cargo_plugin_installer::install_crate(
             &None,


### PR DESCRIPTION
Since fornwall/rust-script/issues/42 has long since been fixed, `cargo-make` should not install such an old version of `rust-script`

This reverts commit 5b7aa311f43b62ccbbf27fcce263be1918f61d2c. 