### PR TITLE
Enable setting default profile by env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2662,6 +2662,10 @@ command = "echo"
 args = [ "running in production profile" ]
 ```
 
+#### Default profile
+
+The default profile is `"development"`. However, this can be overridden by setting the `CARGO_MAKE_DEFAULT_PROFILE` environment variable.
+
 <a name="usage-profiles-built-in"></a>
 #### Built In Profiles
 

--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -87,7 +87,7 @@ fn run(cli_args: CliArgs, global_config: &GlobalConfig) {
     let profile_name = &cli_args
         .profile
         .clone()
-        .unwrap_or(profile::DEFAULT_PROFILE.to_string());
+        .unwrap_or_else(profile::default_profile);
     let normalized_profile_name = profile::set(&profile_name);
 
     environment::load_env_file(cli_args.env_file.clone());

--- a/src/lib/cli_parser.rs
+++ b/src/lib/cli_parser.rs
@@ -104,10 +104,9 @@ fn get_args(
         None => None,
     };
 
-    let default_profile = profile::DEFAULT_PROFILE.to_string();
     let profile_name = cli_parsed
         .get_first_value("profile")
-        .unwrap_or(default_profile);
+        .unwrap_or_else(profile::default_profile);
     cli_args.profile = Some(profile_name.to_string());
 
     cli_args.disable_check_for_updates = cli_parsed.arguments.contains("disable-check-for-updates");
@@ -216,7 +215,7 @@ fn create_cli(global_config: &GlobalConfig) -> CliSpec {
             key: vec!["--profile".to_string(), "-p".to_string()],
             argument_occurrence: ArgumentOccurrence::Single,
             value_type: ArgumentValueType::Single,
-            default_value: Some(profile::DEFAULT_PROFILE.to_string()),
+            default_value: Some(profile::default_profile()),
             help: Some(ArgumentHelp::TextAndParam(
                 "The profile name (will be converted to lower case)".to_string(),
                 "PROFILE".to_string(),

--- a/src/lib/execution_plan.rs
+++ b/src/lib/execution_plan.rs
@@ -217,7 +217,7 @@ fn create_workspace_task(crate_info: &CrateInfo, task: &str) -> Task {
     let profile_name = if envmnt::is_or("CARGO_MAKE_USE_WORKSPACE_PROFILE", true) {
         profile::get()
     } else {
-        profile::DEFAULT_PROFILE.to_string()
+        profile::default_profile()
     };
 
     let filtered_members = filter_workspace_members(&members);

--- a/src/lib/execution_plan_test.rs
+++ b/src/lib/execution_plan_test.rs
@@ -348,7 +348,7 @@ fn create_workspace_task_with_included_members() {
         ],
     );
 
-    profile::set(profile::DEFAULT_PROFILE);
+    profile::set(&profile::default_profile());
 
     let task = create_workspace_task(&crate_info, "some_task");
 
@@ -402,7 +402,7 @@ fn create_workspace_task_with_included_and_skipped_members() {
         &vec!["member2".to_string(), "dir1/member3".to_string()],
     );
 
-    profile::set(profile::DEFAULT_PROFILE);
+    profile::set(&profile::default_profile());
 
     let task = create_workspace_task(&crate_info, "some_task");
 

--- a/src/lib/profile.rs
+++ b/src/lib/profile.rs
@@ -10,8 +10,9 @@ mod profile_test;
 use envmnt;
 
 static PROFILE_ENV_KEY: &str = "CARGO_MAKE_PROFILE";
+static DEFAULT_PROFILE_ENV_KEY: &str = "CARGO_MAKE_DEFAULT_PROFILE";
 static ADDITIONAL_PROFILES_ENV_KEY: &str = "CARGO_MAKE_ADDITIONAL_PROFILES";
-pub(crate) static DEFAULT_PROFILE: &str = "development";
+static DEFAULT_PROFILE: &str = "development";
 
 fn normalize_profile(profile: &str) -> String {
     let profile_normalized = profile.to_lowercase();
@@ -33,7 +34,11 @@ fn normalize_additional_profiles(profiles: &Vec<String>) -> Vec<String> {
 }
 
 pub(crate) fn get() -> String {
-    envmnt::get_or(PROFILE_ENV_KEY, DEFAULT_PROFILE)
+    envmnt::get_or(PROFILE_ENV_KEY, &default_profile())
+}
+
+pub(crate) fn default_profile() -> String {
+    envmnt::get_or(DEFAULT_PROFILE_ENV_KEY, DEFAULT_PROFILE)
 }
 
 pub(crate) fn set(profile: &str) -> String {


### PR DESCRIPTION
It would be useful to be able to set a default profile by env variable. This will help to have a different profile as default when, for example, working in a docker container vs working on the host machine.

This PR add the support for this allowing users to set `CARGO_MAKE_DEFAULT_PROFILE` so all future invocations of `cargo make` will use the given profile. If this variable is not set, it will fall back to the current behaviour of using `development` as the default profile.