### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2322,7 +2322,7 @@ CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = "tools/*"
 
 However there are some cases you will want to skip specific members only if a specific condition is met.<br>
 For example, you want to build a member module only if we are running on a rust nightly compiler.<br>
-This is a simple example of a conditioned skip for member3 and memeber4 (should be defined in the workspace level `Makefile.toml`):
+This is a simple example of a conditioned skip for member3 and member4 (should be defined in the workspace level `Makefile.toml`):
 
 ```toml
 [tasks.workspace-task]
@@ -3570,7 +3570,7 @@ command = "echo"
 args = ["stopping client..."]
 ```
 
-#### Extenal subcommand file
+#### External subcommand file
 
 Another approach is to use a different configuration file for the subcommands.
 


### PR DESCRIPTION
More typos found by typos-cli, set up recently in https://github.com/sagiegurari/cargo-make/pull/1013

@ben1009, any idea why these didnt appear for you?