### PR TITLE
Allowed multiple ignored watch patterns

### DIFF
--- a/src/lib/runner.rs
+++ b/src/lib/runner.rs
@@ -26,7 +26,8 @@ use crate::scriptengine;
 use crate::time_summary;
 use crate::types::{
     CliArgs, Config, DeprecationInfo, EnvInfo, EnvValue, ExecutionPlan, FlowInfo, FlowState,
-    RunTaskInfo, RunTaskName, RunTaskOptions, RunTaskRoutingInfo, Step, Task, TaskWatchOptions,
+    MaybeArray, RunTaskInfo, RunTaskName, RunTaskOptions, RunTaskRoutingInfo, Step, Task,
+    TaskWatchOptions,
 };
 use indexmap::IndexMap;
 use regex::Regex;
@@ -519,7 +520,15 @@ fn create_watch_task(task: &str, options: Option<TaskWatchOptions>, flow_info: &
                 }
 
                 match watch_options.ignore_pattern {
-                    Some(value) => watch_args.extend_from_slice(&["-i".to_string(), value]),
+                    Some(MaybeArray::Single(value)) => {
+                        watch_args.extend_from_slice(&["-i".to_string(), value])
+                    }
+                    Some(MaybeArray::Multiple(values)) => watch_args.extend(
+                        values
+                            .iter()
+                            .flat_map(|value| ["-i".to_string(), value.to_string()])
+                            .collect::<Vec<String>>(),
+                    ),
                     _ => (),
                 };
 

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -892,13 +892,23 @@ pub struct WatchOptions {
     /// Postpone first run until a file changes
     pub postpone: Option<bool>,
     /// Ignore a glob/gitignore-style pattern
-    pub ignore_pattern: Option<String>,
+    pub ignore_pattern: Option<MaybeArray<String>>,
     /// Do not use .gitignore files
     pub no_git_ignore: Option<bool>,
     /// Show paths that changed
     pub why: Option<bool>,
     /// Select which files/folders to watch
     pub watch: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(untagged)]
+/// Could be an array or single value
+pub enum MaybeArray<T> {
+    /// Single value
+    Single(T),
+    /// Multiple values
+    Multiple(Vec<T>),
 }
 
 impl PartialEq for WatchOptions {


### PR DESCRIPTION
Allows for multiple ignore patterns while watching as is allowed [here](https://github.com/watchexec/cargo-watch/blob/f931767c766b86005509b42f2f582c8ae2fb6221/src/args.rs#L141).