### PR TITLE
Add global environment variables to the root package of the workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1764,6 +1764,14 @@ The following environment variables will be set by cargo-make if `Cargo.toml` fi
 * **`CARGO_MAKE_CRATE_HOMEPAGE`** - Holds the crate homepage link from the `Cargo.toml` file in the current working directory.
 * **`CARGO_MAKE_CRATE_REPOSITORY`** - Holds the crate repository link from the `Cargo.toml` file in the current working directory.
 
+* **`CARGO_MAKE_WORKSPACE_PACKAGE_NAME`** - Holds the root package name of the workspace from the `Cargo.toml` file in the current working directory.
+* **`CARGO_MAKE_WORKSPACE_PACKAGE_VERSION`** - Holds the root package version of the workspace from the `Cargo.toml` file in the current working directory.
+* **`CARGO_MAKE_WORKSPACE_PACKAGE_DESCRIPTION`** - Holds the root package description of the workspace from the `Cargo.toml` file in the current working directory.
+* **`CARGO_MAKE_WORKSPACE_PACKAGE_LICENSE`** - Holds the root package license of the workspace from the `Cargo.toml` file in the current working directory.
+* **`CARGO_MAKE_WORKSPACE_PACKAGE_DOCUMENTATION`** - Holds the root package documentation link of the workspace from the `Cargo.toml` file in the current working directory.
+* **`CARGO_MAKE_WORKSPACE_PACKAGE_HOMEPAGE`** - Holds the root package homepage link of the workspace from the `Cargo.toml` file in the current working directory.
+* **`CARGO_MAKE_WORKSPACE_PACKAGE_REPOSITORY`** - Holds the root package repository link of the workspace from the `Cargo.toml` file in the current working directory.
+
 The following environment variables will be set by cargo-make if the project is part of a git repo:
 
 * **`CARGO_MAKE_GIT_BRANCH`** - The current branch name.

--- a/src/lib/environment/mod.rs
+++ b/src/lib/environment/mod.rs
@@ -397,6 +397,11 @@ fn setup_env_for_crate(home: Option<PathBuf>) -> CrateInfo {
     env_options.separator = Some(",".to_string());
     envmnt::set_list_with_options("CARGO_MAKE_CRATE_WORKSPACE_MEMBERS", &members, &env_options);
 
+    if let Some(package) = workspace.package.as_ref() {
+        envmnt::set_optional("CARGO_MAKE_WORKSPACE_PACKAGE_NAME", &package.name);
+        envmnt::set_optional("CARGO_MAKE_WORKSPACE_PACKAGE_VERSION", &package.version);
+    }
+
     // check if Cargo.lock file exists in working directory
     let lock_file = Path::new("Cargo.lock");
     let lock_file_exists = lock_file.exists();

--- a/src/lib/environment/mod.rs
+++ b/src/lib/environment/mod.rs
@@ -400,6 +400,20 @@ fn setup_env_for_crate(home: Option<PathBuf>) -> CrateInfo {
     if let Some(package) = workspace.package.as_ref() {
         envmnt::set_optional("CARGO_MAKE_WORKSPACE_PACKAGE_NAME", &package.name);
         envmnt::set_optional("CARGO_MAKE_WORKSPACE_PACKAGE_VERSION", &package.version);
+        envmnt::set_optional(
+            "CARGO_MAKE_WORKSPACE_PACKAGE_DESCRIPTION",
+            &package.description,
+        );
+        envmnt::set_optional("CARGO_MAKE_WORKSPACE_PACKAGE_LICENSE", &package.license);
+        envmnt::set_optional(
+            "CARGO_MAKE_WORKSPACE_PACKAGE_DOCUMENTATION",
+            &package.documentation,
+        );
+        envmnt::set_optional("CARGO_MAKE_WORKSPACE_PACKAGE_HOMEPAGE", &package.homepage);
+        envmnt::set_optional(
+            "CARGO_MAKE_WORKSPACE_PACKAGE_REPOSITORY",
+            &package.repository,
+        );
     }
 
     // check if Cargo.lock file exists in working directory

--- a/src/lib/execution_plan_test.rs
+++ b/src/lib/execution_plan_test.rs
@@ -163,6 +163,7 @@ fn create_workspace_task_no_members() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let task = create_workspace_task(&crate_info, "some_task");
@@ -189,6 +190,7 @@ fn create_workspace_task_with_members() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     envmnt::remove("CARGO_MAKE_USE_WORKSPACE_PROFILE");
@@ -235,6 +237,7 @@ fn create_workspace_task_with_members_no_workspace_profile() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     envmnt::set_bool("CARGO_MAKE_USE_WORKSPACE_PROFILE", false);
@@ -278,6 +281,7 @@ fn create_workspace_task_with_members_and_arguments() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     envmnt::remove("CARGO_MAKE_USE_WORKSPACE_PROFILE");
@@ -332,6 +336,7 @@ fn create_workspace_task_with_included_members() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     envmnt::set_list(
@@ -385,6 +390,7 @@ fn create_workspace_task_with_included_and_skipped_members() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     envmnt::set_list(
@@ -431,6 +437,7 @@ fn create_workspace_task_extend_workspace_makefile() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     envmnt::set("CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE", "true");
@@ -459,6 +466,7 @@ fn is_workspace_flow_true_default() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let task = Task::new();
@@ -486,6 +494,7 @@ fn is_workspace_flow_false_in_config() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let task = Task::new();
@@ -516,6 +525,7 @@ fn is_workspace_flow_true_in_config() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let task = Task::new();
@@ -546,6 +556,7 @@ fn is_workspace_flow_true_in_task() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let mut task = Task::new();
@@ -574,6 +585,7 @@ fn is_workspace_flow_default_false_in_task_and_sub_flow() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let task = Task::new();
@@ -601,6 +613,7 @@ fn is_workspace_flow_true_in_task_and_sub_flow() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let mut task = Task::new();
@@ -629,6 +642,7 @@ fn is_workspace_flow_false_in_task_and_sub_flow() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let mut task = Task::new();
@@ -657,6 +671,7 @@ fn is_workspace_flow_task_not_defined() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let config = Config {
@@ -703,6 +718,7 @@ fn is_workspace_flow_disabled_via_cli() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let mut task = Task::new();
@@ -731,6 +747,7 @@ fn is_workspace_flow_disabled_via_task() {
         members: Some(members),
         exclude: None,
         dependencies: None,
+        package: None,
     });
 
     let mut task = Task::new();

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -223,6 +223,8 @@ pub struct Workspace {
     pub exclude: Option<Vec<String>>,
     /// workspace level dependencies
     pub dependencies: Option<IndexMap<String, CrateDependency>>,
+    /// root package
+    pub package: Option<PackageInfo>,
 }
 
 impl Workspace {
@@ -232,7 +234,7 @@ impl Workspace {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 /// Holds crate package information loaded from the Cargo.toml file package section.
 pub struct PackageInfo {
     /// name


### PR DESCRIPTION
In this Pull Request (PR), we have introduced global environment variables to the root package of the workspace.

The following environment variables are added:

- `CARGO_MAKE_WORKSPACE_PACKAGE_NAME`
- `CARGO_MAKE_WORKSPACE_PACKAGE_VERSION`
- `CARGO_MAKE_WORKSPACE_PACKAGE_DESCRIPTION`
- `CARGO_MAKE_WORKSPACE_PACKAGE_LICENSE`
- `CARGO_MAKE_WORKSPACE_PACKAGE_HOMEPAGE`
- `CARGO_MAKE_WORKSPACE_PACKAGE_REPOSITORY`
