### PR TITLE
SQL and serde support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "cliparser",
  "colored",
  "ctrlc",
+ "diesel",
  "dirs-next",
  "duckscript",
  "duckscriptsdk",
@@ -241,6 +242,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "840dbb7bdd1f2c4d434d6b08420ef204e0bfad0ab31a07a80a1248d24cc6e38b"
 dependencies = [
  "envmnt",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -339,12 +342,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "diesel"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e13bab2796f412722112327f3e575601a3e9cdcbe426f0d30dbf43f3f5dc71"
+dependencies = [
+ "diesel_derives",
+ "serde_json",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "dsl_auto_type",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
+dependencies = [
+ "syn",
 ]
 
 [[package]]
@@ -383,6 +453,20 @@ name = "dissimilar"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9abe6314103864cc2d8901b7ae224e0ab1a103a0a416661b4097b0779b607"
+dependencies = [
+ "darling",
+ "either",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "duckscript"
@@ -614,8 +698,10 @@ dependencies = [
 [[package]]
 name = "git_info"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641b847f0375f4b2c595438eefc17a9c0fbf47b400cbdd1ad9332bf1e16b779d"
+source = "git+https://github.com/SamuelMarks/git_info?branch=serde#6538c9d12b83c2a2ca9f6b5285f1c3bfb002b572"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "glob"
@@ -708,6 +794,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1175,8 +1267,10 @@ dependencies = [
 [[package]]
 name = "rust_info"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821495e93d15e4433347b3a72e97005f1d8a620dc88d46637fecfcb16e98043d"
+source = "git+https://github.com/SamuelMarks/rust_info?branch=serde#62a8e08a0b848f27d67748b268f9e83779734ed1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "rustix"
@@ -1369,6 +1463,12 @@ checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
 dependencies = [
  "vte",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,17 +45,18 @@ path = "src/makers.rs"
 
 [dependencies]
 cargo_metadata = "^0.18"
-ci_info = "^0.14.14"
+ci_info = { version = "^0.14.14", features=["serde-1"] }
 cliparser = "^0.1.2"
 colored = "^2"
 ctrlc = "^3"
+diesel = { version = "2.2.3", optional = true, features = ["serde_json"] }
 dirs-next = "^2"
 duckscript = "^0.8.0"
 duckscriptsdk = { version = "^0.9.3", default-features = false }
 envmnt = "^0.10.4"
 fern = "^0.6"
 fsio = { version = "^0.4", features = ["temp-path"] }
-git_info = "^0.1.2"
+git_info = { git = "https://github.com/SamuelMarks/git_info", branch = "serde", features = ["serde"] }
 glob = "^0.3.1"
 home = "^0.5"
 ignore = "^0.4"
@@ -67,7 +68,8 @@ once_cell = "^1.19.0"
 petgraph = "^0.6.5"
 regex = "^1.10"
 run_script = "^0.10"
-rust_info = "^0.3.1"
+# rust_info = "^0.3.1"
+rust_info = { git = "https://github.com/SamuelMarks/rust_info", branch = "serde", features = ["serde"] }
 semver = "^1"
 serde = "^1"
 serde_derive = "^1"
@@ -87,6 +89,7 @@ expect-test = "^1"
 nu-ansi-term = "^0.50"
 
 [features]
+diesel = ["dep:diesel"]
 tls-rustls = ["duckscriptsdk/tls-rustls"]
 tls-native = ["duckscriptsdk/tls-native"]
 tls = ["tls-rustls"]                      # alias for backward compatibility

--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -277,7 +277,7 @@ pub enum CrateDependency {
     Info(CrateDependencyInfo),
 }
 
-#[derive(Deserialize, Debug, Clone, Default)]
+#[derive(Deserialize, Serialize, Debug, Clone, Default)]
 /// Holds crate information loaded from the Cargo.toml file.
 pub struct CrateInfo {
     /// package info
@@ -295,7 +295,7 @@ impl CrateInfo {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 /// Holds env information
 pub struct EnvInfo {
     /// Rust info
@@ -308,7 +308,8 @@ pub struct EnvInfo {
     pub ci_info: CiInfo,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "diesel", derive(diesel::Insertable))]
 /// Holds flow information
 pub struct FlowInfo {
     /// The flow config object
@@ -332,6 +333,7 @@ pub struct FlowInfo {
 }
 
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "diesel", derive(diesel::Insertable))]
 /// Holds mutable flow state
 pub struct FlowState {
     /// timing info for summary
@@ -1107,6 +1109,7 @@ pub enum ConditionScriptValue {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[cfg_attr(feature = "diesel", derive(diesel::Insertable))]
 /// Holds a single task configuration such as command and dependencies list
 pub struct Task {
     /// if true, it should ignore all data in base task
@@ -2427,7 +2430,8 @@ impl ExternalConfig {
     }
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[cfg_attr(feature = "diesel", derive(diesel::Insertable))]
 /// Execution plan step to execute
 pub struct Step {
     /// The task name


### PR DESCRIPTION
WiP

Related PRs:
- https://github.com/sagiegurari/rust_info/pull/7
- https://github.com/sagiegurari/git_info/pull/6

Took care to make the dependencies optional. I am preparing `cargo-make` to support #1110: asynchronous and distributed task execution. To support this, it is becoming necessary to store tasks and run task flows (execution plans). Whether that's as JSON (say for Redis or a flat-file solution), or as proper SQL tables (say for PostgreSQL or SQLite).