### PR TITLE
Improve log readability, minor code cleanups

### DIFF
--- a/src/lib/cli.rs
+++ b/src/lib/cli.rs
@@ -120,6 +120,7 @@ pub fn run(
     time_summary::add(&mut time_summary_vec, "[Setup Env]", step_time);
 
     let crate_name = envmnt::get_or("CARGO_MAKE_CRATE_NAME", "");
+    info!("");
     if crate_name.len() > 0 {
         info!("Project: {}", &crate_name);
     }

--- a/src/lib/environment/crateinfo.rs
+++ b/src/lib/environment/crateinfo.rs
@@ -274,15 +274,15 @@ pub(crate) fn load() -> Result<CrateInfo, CargoMakeError> {
 
 pub(crate) fn load_from(file_path: PathBuf) -> Result<CrateInfo, CargoMakeError> {
     if file_path.exists() {
-        info!("Calling cargo metadata to extract project info");
+        debug!("Calling cargo metadata to extract project info");
 
         match MetadataCommand::new().manifest_path(&file_path).exec() {
             Ok(metadata) => {
-                info!("Cargo metadata done");
-                debug!("Cargo metadata: {:#?}", &metadata);
+                debug!("Cargo metadata done");
+                trace!("Cargo metadata: {:#?}", &metadata);
                 let mut crate_info = convert_metadata_to_crate_info(&metadata);
 
-                debug!("Reading file: {:#?}", &file_path);
+                trace!("Reading file: {:#?}", &file_path);
                 let crate_info_string = fsio::file::read_text_file(&file_path)?;
 
                 let crate_info_deserialized: CrateInfoMinimal =
@@ -298,7 +298,7 @@ pub(crate) fn load_from(file_path: PathBuf) -> Result<CrateInfo, CargoMakeError>
 
                 load_workspace_members(&mut crate_info);
 
-                debug!("Loaded Cargo.toml: {:#?}", &crate_info);
+                trace!("Loaded Cargo.toml: {:#?}", &crate_info);
 
                 Ok(crate_info)
             }

--- a/src/lib/execution_plan.rs
+++ b/src/lib/execution_plan.rs
@@ -13,7 +13,7 @@ use crate::logger;
 use crate::profile;
 use crate::proxy_task::create_proxy_task;
 use crate::types::{
-    Config, CrateInfo, EnvValue, ExecutionPlan, ScriptValue, Step, Task, TaskIdentifier, Workspace,
+    Config, CrateInfo, EnvValue, ExecutionPlan, ScriptValue, Step, Task, TaskIdentifier,
 };
 use fsio::path::{get_basename, get_parent_directory};
 use glob::Pattern;
@@ -208,9 +208,7 @@ fn create_workspace_task(crate_info: &CrateInfo, task: &str) -> Task {
         );
     }
 
-    let members = if crate_info.workspace.is_some() {
-        let workspace_clone = crate_info.workspace.clone();
-        let workspace = workspace_clone.unwrap_or(Workspace::new());
+    let members = if let Some(workspace) = crate_info.workspace.clone() {
         workspace.members.unwrap_or(vec![])
     } else {
         envmnt::get_list("CARGO_MAKE_CRATE_WORKSPACE_MEMBERS").unwrap_or(vec![])

--- a/src/lib/execution_plan.rs
+++ b/src/lib/execution_plan.rs
@@ -230,9 +230,7 @@ fn create_workspace_task(crate_info: &CrateInfo, task: &str) -> Task {
 
         script_lines.push("workspace_directory = pwd".to_string());
         for member in &filtered_members {
-            let mut cd_line = "cd ./".to_string();
-            cd_line.push_str(&member.replace("\\", "/"));
-            script_lines.push(cd_line);
+            script_lines.push(format!("cd ./{}", member.replace("\\", "/")));
 
             //get member name
             let member_name = match Path::new(&member).file_name() {

--- a/src/lib/execution_plan_test.rs
+++ b/src/lib/execution_plan_test.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::descriptor;
-use crate::types::{ConfigSection, DependencyIdentifier, PlatformOverrideTask, TaskWatchOptions};
+use crate::types::{
+    ConfigSection, DependencyIdentifier, PlatformOverrideTask, TaskWatchOptions, Workspace,
+};
 
 #[test]
 fn get_actual_task_name_not_found() {


### PR DESCRIPTION
- reduces log level of cargo metadata parsing step, this is not significantly important but noisy
- added an empty line before project tasks, makes it easier visually to find where a different project build started
- refactored up some code