### PR TITLE
Platform name freebsd supports

### DIFF
--- a/src/lib/types.rs
+++ b/src/lib/types.rs
@@ -22,6 +22,8 @@ pub fn get_platform_name() -> String {
         "windows".to_string()
     } else if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
         "mac".to_string()
+    } else if cfg!(target_os = "freebsd") {
+        "freebsd".to_string()
     } else {
         "linux".to_string()
     }


### PR DESCRIPTION
This PR adds support for Freebsd platform name.