### PR TITLE
Enable LTO and codegen-units = 1 optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,7 @@ tls-rustls = ["duckscriptsdk/tls-rustls"]
 tls-native = ["duckscriptsdk/tls-native"]
 tls = ["tls-rustls"]                      # alias for backward compatibility
 default = ["tls-rustls"]
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Resolves https://github.com/sagiegurari/cargo-make/issues/1202

Also, I decided to enable `codegen-units = 1` additionally in the Release profile since it allows us to squeeze even more optimizations with LTO.