### PR TITLE
feat(log): force enable command output by envvar

### DIFF
--- a/src/lib/command.rs
+++ b/src/lib/command.rs
@@ -184,7 +184,7 @@ pub(crate) fn run_command_get_output(
 
     command.stdin(Stdio::inherit());
 
-    if silent {
+    if silent && !envmnt::is("CARGO_MAKE_COMMAND_FORCE_OUTPUT") {
         command.stdout(Stdio::null()).stderr(Stdio::null());
     } else if ctrl_c_handling {
         if capture_output {


### PR DESCRIPTION
workaround #1069

Currently `--loglevel error` will imply `silent`, and will hide command output. 
I'm not sure what's the best way to change that without breaking previous behavior, so just introduced an env var to forceabily enable command output.

Another idea is to let `--loglevel` only changes `cargo make`'s log, i.e., those collected by the logger. `--silent` can keep the behavior as before. However, it becomes a separate flag, adn won't be enabled by `--loglevel error`.