### PR TITLE
docs: fix markdown escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -2021,7 +2021,7 @@ args = ["audit"]
 ```
 
 cargo-make will first check the command is available.<br>
-Only if the command is not available, it will attempt to install it by running **cargo install cargo-<first arg>**<br>
+Only if the command is not available, it will attempt to install it by running **cargo install cargo-\<first arg\>**<br>
 In case the cargo plugin has a different name, you can specify it manually via **install_crate** attribute.<br>
 You can specify additional installation arguments using the **install_crate_args** attribute (for example: version).
 

--- a/docs/_includes/content.md
+++ b/docs/_includes/content.md
@@ -1882,7 +1882,7 @@ args = ["audit"]
 ```
 
 cargo-make will first check the command is available.<br>
-Only if the command is not available, it will attempt to install it by running **cargo install cargo-<first arg>**<br>
+Only if the command is not available, it will attempt to install it by running **cargo install cargo-\<first arg\>**<br>
 In case the cargo plugin has a different name, you can specify it manually via **install_crate** attribute.<br>
 You can specify additional installation arguments using the **install_crate_args** attribute (for example: version).
 


### PR DESCRIPTION
It wasn't rendering correctly on markdown and I didn't know what was going to happen.

before (README):
<img width="412" alt="image" src="https://github.com/user-attachments/assets/a63b7cbd-5b81-47ba-9afd-062c347f0199" />

before (doc):
<img width="517" alt="image" src="https://github.com/user-attachments/assets/e4c4334b-c138-475b-ab80-bd8e034a9b07" />

after (README):
<img width="414" alt="image" src="https://github.com/user-attachments/assets/da05bd32-1c69-4aa4-be90-1a0d06e345ee" />

after (doc):
<img width="476" alt="image" src="https://github.com/user-attachments/assets/33603129-5223-4b98-bfc9-7d7a058171ae" />

