### PR TITLE
Fix crash on recursive extend

### DIFF
--- a/examples/recursive.toml
+++ b/examples/recursive.toml
@@ -1,0 +1,4 @@
+extend = { path = "recursive.toml", optional = false }
+
+[tasks.ping]
+script = "echo ping"

--- a/src/lib/descriptor/mod.rs
+++ b/src/lib/descriptor/mod.rs
@@ -27,6 +27,7 @@ use crate::{io, scriptengine, version};
 use fsio::path::as_path::AsPath;
 use fsio::path::from_path::FromPath;
 use indexmap::IndexMap;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
@@ -254,11 +255,17 @@ fn merge_external_configs(
 fn load_descriptor_extended_makefiles(
     parent_path: &str,
     extend_struct: &Extend,
+    visited_files: &mut HashSet<String>,
 ) -> Result<ExternalConfig, CargoMakeError> {
     match extend_struct {
-        Extend::Path(base_file) => {
-            load_external_descriptor(parent_path, &base_file, true, false, RelativeTo::Makefile)
-        }
+        Extend::Path(base_file) => load_external_descriptor(
+            parent_path,
+            &base_file,
+            true,
+            false,
+            RelativeTo::Makefile,
+            visited_files,
+        ),
         Extend::Options(extend_options) => {
             let force = !extend_options.optional.unwrap_or(false);
             let relative_to_str = extend_options
@@ -278,7 +285,14 @@ fn load_descriptor_extended_makefiles(
                     RelativeTo::Makefile
                 }
             };
-            load_external_descriptor(parent_path, &extend_options.path, force, false, relative_to)
+            load_external_descriptor(
+                parent_path,
+                &extend_options.path,
+                force,
+                false,
+                relative_to,
+                visited_files,
+            )
         }
         Extend::List(extend_list) => {
             let mut ordered_list_config = ExternalConfig::new();
@@ -288,6 +302,7 @@ fn load_descriptor_extended_makefiles(
                 let entry_config = load_descriptor_extended_makefiles(
                     parent_path,
                     &Extend::Options(extend_options),
+                    visited_files,
                 )?;
 
                 // merge configs
@@ -329,6 +344,7 @@ fn load_external_descriptor(
     force: bool,
     set_env: bool,
     relative_to: RelativeTo,
+    visited_files: &mut HashSet<String>,
 ) -> Result<ExternalConfig, CargoMakeError> {
     debug!(
         "Loading tasks from file: {} base directory: {}, relative to: {:#?}",
@@ -377,6 +393,11 @@ fn load_external_descriptor(
         let file_path_string: String = FromPath::from_path(&file_path);
         let absolute_file_path = io::canonicalize_to_string(&file_path_string);
 
+        // Check if this file has been visited to detect recursive extends
+        if visited_files.contains(&absolute_file_path) {
+            return Err(CargoMakeError::RecursiveExtend(absolute_file_path));
+        }
+
         if set_env {
             envmnt::set("CARGO_MAKE_MAKEFILE_PATH", &absolute_file_path);
         }
@@ -393,6 +414,10 @@ fn load_external_descriptor(
 
         run_load_script(&file_config)?;
 
+        // Mark the file as visited so the next time we see it in the same extend tree
+        // we know that this is a recursive/circular extend
+        visited_files.insert(absolute_file_path.clone());
+
         match file_config.extend {
             Some(ref extend_struct) => {
                 let parent_path_buf = Path::new(&file_path_string).join("..");
@@ -404,7 +429,7 @@ fn load_external_descriptor(
                 debug!("External config parent path: {}", &parent_path);
 
                 let base_file_config =
-                    load_descriptor_extended_makefiles(&parent_path, extend_struct)?;
+                    load_descriptor_extended_makefiles(&parent_path, extend_struct, visited_files)?;
 
                 merge_external_configs(file_config.clone(), base_file_config)
             }
@@ -578,8 +603,14 @@ fn load_descriptors(
 ) -> Result<Config, CargoMakeError> {
     let default_config = load_internal_descriptors(stable, experimental, modify_core_tasks)?;
 
-    let mut external_config =
-        load_external_descriptor(".", file_name, force, true, RelativeTo::Makefile)?;
+    let mut external_config = load_external_descriptor(
+        ".",
+        file_name,
+        force,
+        true,
+        RelativeTo::Makefile,
+        &mut HashSet::new(),
+    )?;
 
     external_config = match std::env::var("CARGO_MAKE_WORKSPACE_MAKEFILE") {
         Ok(workspace_makefile) => {
@@ -597,6 +628,7 @@ fn load_descriptors(
                                     false,
                                     false,
                                     RelativeTo::Makefile,
+                                    &mut HashSet::new(),
                                 )?;
                                 merge_external_configs(external_config, workspace_config)?
                             }

--- a/src/lib/descriptor/mod_test.rs
+++ b/src/lib/descriptor/mod_test.rs
@@ -492,9 +492,15 @@ fn load_internal_descriptors_modify_namespace() {
 #[test]
 #[ignore]
 fn load_external_descriptor_no_file() {
-    let config =
-        load_external_descriptor(".", "bad_file.toml2", false, false, RelativeTo::Makefile)
-            .unwrap();
+    let config = load_external_descriptor(
+        ".",
+        "bad_file.toml2",
+        false,
+        false,
+        RelativeTo::Makefile,
+        &mut HashSet::new(),
+    )
+    .unwrap();
 
     assert!(config.config.is_none());
     assert!(config.env.is_none());
@@ -504,7 +510,15 @@ fn load_external_descriptor_no_file() {
 #[test]
 #[should_panic]
 fn load_external_descriptor_no_file_force() {
-    load_external_descriptor(".", "bad_file.toml2", true, false, RelativeTo::Makefile).unwrap();
+    load_external_descriptor(
+        ".",
+        "bad_file.toml2",
+        true,
+        false,
+        RelativeTo::Makefile,
+        &mut HashSet::new(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -516,6 +530,7 @@ fn load_external_descriptor_extended_not_found_force() {
         true,
         false,
         RelativeTo::Makefile,
+        &mut HashSet::new(),
     )
     .unwrap();
 }
@@ -529,6 +544,7 @@ fn load_external_descriptor_simple_file() {
         true,
         false,
         RelativeTo::Makefile,
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -544,6 +560,34 @@ fn load_external_descriptor_simple_file() {
 
 #[test]
 #[ignore]
+fn load_external_descriptor_recursive_file() {
+    let result = load_external_descriptor(
+        ".",
+        "./examples/recursive.toml",
+        true,
+        false,
+        RelativeTo::Makefile,
+        &mut HashSet::new(),
+    );
+
+    let path_string: String = Path::new("./examples/recursive.toml")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let full_path = io::canonicalize_to_string(&path_string);
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        CargoMakeError::RecursiveExtend(file_path) => assert_eq!(full_path, file_path),
+        other_error => panic!(
+            "Expected CargoMakeError::RecursiveExtend, found {:?}",
+            other_error
+        ),
+    }
+}
+
+#[test]
+#[ignore]
 fn load_external_descriptor_extending_file() {
     let config = load_external_descriptor(
         ".",
@@ -551,6 +595,7 @@ fn load_external_descriptor_extending_file() {
         true,
         false,
         RelativeTo::Makefile,
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -579,6 +624,7 @@ fn load_external_descriptor_extending_file_sub_folder() {
         true,
         false,
         RelativeTo::Makefile,
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -616,6 +662,7 @@ fn load_external_descriptor_simple_file_from_crate_root() {
         true,
         false,
         RelativeTo::CrateRoot,
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -638,6 +685,7 @@ fn load_external_descriptor_simple_file_from_git_root() {
         true,
         false,
         RelativeTo::GitRoot,
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -663,6 +711,7 @@ fn load_external_descriptor_set_env() {
         true,
         true,
         RelativeTo::Makefile,
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -673,13 +722,15 @@ fn load_external_descriptor_set_env() {
 fn load_external_descriptor_min_version_broken_makefile_nopanic() {
     // Ensure that we can properly get the min_version of a descriptor that
     // doesn't match our internal data-structures.
+
     assert_eq!(
         load_external_descriptor(
             ".",
             "src/lib/test/makefiles/broken_makefile_minversion.toml",
             false,
             false,
-            RelativeTo::Makefile
+            RelativeTo::Makefile,
+            &mut HashSet::new(),
         )
         .err()
         .unwrap()
@@ -700,6 +751,7 @@ fn load_external_descriptor_broken_makefile_panic() {
         false,
         false,
         RelativeTo::Makefile,
+        &mut HashSet::new(),
     )
     .unwrap();
 }
@@ -780,6 +832,7 @@ fn load_descriptor_extended_makefiles_path_exists() {
     let descriptor = load_descriptor_extended_makefiles(
         &parent_path,
         &Extend::Path("src/lib/test/makefiles/test1.toml".to_string()),
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -795,6 +848,7 @@ fn load_descriptor_extended_makefiles_path_not_exists() {
     load_descriptor_extended_makefiles(
         &parent_path,
         &Extend::Path("src/lib/test/makefiles/bad.toml".to_string()),
+        &mut HashSet::new(),
     )
     .unwrap();
 }
@@ -810,6 +864,7 @@ fn load_descriptor_extended_makefiles_options_exists() {
             optional: None,
             relative: None,
         }),
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -829,6 +884,7 @@ fn load_descriptor_extended_makefiles_options_not_exists() {
             optional: None,
             relative: None,
         }),
+        &mut HashSet::new(),
     )
     .unwrap();
 }
@@ -844,6 +900,7 @@ fn load_descriptor_extended_makefiles_options_exists_optional() {
             optional: Some(true),
             relative: None,
         }),
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -862,6 +919,7 @@ fn load_descriptor_extended_makefiles_options_exists_not_optional() {
             optional: Some(false),
             relative: None,
         }),
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -881,6 +939,7 @@ fn load_descriptor_extended_makefiles_options_not_exists_optional() {
             optional: Some(true),
             relative: None,
         }),
+        &mut HashSet::new(),
     )
     .unwrap();
 
@@ -900,6 +959,7 @@ fn load_descriptor_extended_makefiles_options_not_exists_not_optional() {
             optional: Some(false),
             relative: None,
         }),
+        &mut HashSet::new(),
     )
     .unwrap();
 }
@@ -920,7 +980,9 @@ fn load_descriptor_extended_makefiles_list_exists() {
             relative: None,
         },
     ];
-    let descriptor = load_descriptor_extended_makefiles(&parent_path, &Extend::List(list)).unwrap();
+    let descriptor =
+        load_descriptor_extended_makefiles(&parent_path, &Extend::List(list), &mut HashSet::new())
+            .unwrap();
 
     let tasks = descriptor.tasks.unwrap();
     assert!(tasks.contains_key("test1"));
@@ -944,7 +1006,8 @@ fn load_descriptor_extended_makefiles_list_not_exists() {
             relative: None,
         },
     ];
-    load_descriptor_extended_makefiles(&parent_path, &Extend::List(list)).unwrap();
+    load_descriptor_extended_makefiles(&parent_path, &Extend::List(list), &mut HashSet::new())
+        .unwrap();
 }
 
 #[test]
@@ -963,7 +1026,9 @@ fn load_descriptor_extended_makefiles_list_exists_optional() {
             relative: None,
         },
     ];
-    let descriptor = load_descriptor_extended_makefiles(&parent_path, &Extend::List(list)).unwrap();
+    let descriptor =
+        load_descriptor_extended_makefiles(&parent_path, &Extend::List(list), &mut HashSet::new())
+            .unwrap();
 
     let tasks = descriptor.tasks.unwrap();
     assert!(tasks.contains_key("test1"));

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -46,6 +46,9 @@ pub enum CargoMakeError {
     #[strum(to_string = "Task {0:#?} is {1}")]
     TaskIs(String, &'static str) = 110,
 
+    #[strum(to_string = "Recursive extend detected at file: {0:#?}")]
+    RecursiveExtend(String) = 111,
+
     #[strum(to_string = "{0}")]
     NotFound(String) = 404,
 


### PR DESCRIPTION
Attempt to resolve https://github.com/sagiegurari/cargo-make/issues/1302

Pass a HashSet of visited files down the call stack of `load_external_descriptor` and `load_descriptor_extended_makefiles` for cyclic/recursive extend detection. Return an error if a recursion is detected.